### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master # allthough  master is push protected we still keep it
-      - dev
+      - development
   pull_request: # runs on all PR
 
 jobs:


### PR DESCRIPTION
This adds a very basic CI that runs unit tests on every pull request and pushes to dev and master

Currently uses node version 12 but we can easily make this a test [against multiple versions](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix), we just need to specify which versions we want to support.