### PR TITLE
Remove statuses package, use built in http.STATUS_CODES

### DIFF
--- a/lib/errors/oauth-error.js
+++ b/lib/errors/oauth-error.js
@@ -5,7 +5,7 @@
  */
 var _ = require('lodash');
 var util = require('util');
-var statuses = require('statuses');
+var http = require('http');
 /**
  * Constructor.
  */
@@ -24,7 +24,7 @@ function OAuthError(messageOrError, properties) {
     properties.inner = error;
   }
   if (_.isEmpty(message)) {
-    message = statuses[properties.code];
+    message = http.STATUS_CODES[properties.code];
   }
   this.code = this.status = this.statusCode = properties.code;
   this.message = message;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,11 +1619,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "promisify-any": "2.0.1",
-    "statuses": "1.5.0",
     "type-is": "1.6.18"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR simply removes the statuses dependency from the module and uses the built in 

The [http.STATUS_CODES](https://nodejs.org/api/http.html#http_http_status_codes) object has been a part of Node since the beginning, since v0.1.22 actually, so this should not affect backwards combability. 

The `statuses` package was only being used in the OAuthError class (`lib/errors/oauth-error.js`). The OAuthError class takes two properties, first being either a message or an Error object instance, while the second property can support taking a "code" along with a few other properties ([read more in the docs](https://oauth2-server.readthedocs.io/en/latest/api/errors/oauth-error.html?highlight=OAuthError) about this class).

Anyways, if the second property did not contain anything, it will default to the value of `{code: 500}`, and then it will access the http.STATUS_CODES to retrieve the _message_ for this error to then attach it to the custom OAuthError object.

This addresses and resolves https://github.com/node-oauth/node-oauth2-server/issues/21