### PR TITLE
Add commit message convention and coding rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ $ git checkout -b feature-xyz # or fix-xyz
 
 ### Commit message convention
 
-Commit title must meet [angular commit message format](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)
+We use a commit convention, inspired by [angular commit message format](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)
 with ticket number at the end of summary:
 
 ```


### PR DESCRIPTION
It is necessary to use semantics in commit messages so that it is clear what meaning commit have in release process and affected release type (major/minor/patch). The semantics proposed in angular are very widely used - it is really convenient and understandable.

It is also necessary to mention the testing and documentation.