### PR TITLE
Bearer regular expression matching in authenticate handler

### DIFF
--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -140,7 +140,7 @@ AuthenticateHandler.prototype.getTokenFromRequest = function(request) {
 
 AuthenticateHandler.prototype.getTokenFromRequestHeader = function(request) {
   const token = request.get('Authorization');
-  const matches = token.match(/Bearer\s(\S+)/);
+  const matches = token.match(/^Bearer\s(\S+)/);
 
   if (!matches) {
     throw new InvalidRequestError('Invalid request: malformed authorization header');

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -5,6 +5,7 @@
  */
 
 const AuthenticateHandler = require('../../../lib/handlers/authenticate-handler');
+const InvalidRequestError = require('../../../lib/errors/invalid-request-error');
 const Request = require('../../../lib/request');
 const sinon = require('sinon');
 const should = require('chai').should();
@@ -16,6 +17,33 @@ const ServerError = require('../../../lib/errors/server-error');
 
 describe('AuthenticateHandler', function() {
   describe('getTokenFromRequest()', function() {
+    describe('with bearer token in the request authorization header', function() {
+      it('should throw an error if the token is malformed', () => {
+        const handler = new AuthenticateHandler({
+          model: { getAccessToken() {} },
+        });
+        const request = new Request({
+          body: {},
+          headers: {
+            Authorization: 'foo Bearer bar',
+          },
+          method: 'ANY',
+          query: {},
+        });
+
+        try {
+          handler.getTokenFromRequestHeader(request);
+
+          should.fail('should.fail', '');
+        } catch (e) {
+          e.should.be.an.instanceOf(InvalidRequestError);
+          e.message.should.equal(
+            'Invalid request: malformed authorization header',
+          );
+        }
+      });
+    });
+
     describe('with bearer token in the request authorization header', function() {
       it('should call `getTokenFromRequestHeader()`', function() {
         const handler = new AuthenticateHandler({ model: { getAccessToken: function() {} } });


### PR DESCRIPTION
## Summary

This pr fixes the regex for checking the bearer token.

## Linked issue(s)

Issue #89, point 15, original pr https://github.com/oauthjs/node-oauth2-server/pull/614


## Added tests?

Yes

## OAuth2 standard

RFC 6750 | OAuth 2.0 Bearer Token Usage | Section 2.1
https://tools.ietf.org/html/rfc6750#section-2.1

