### PR TITLE
RefreshTokenGrant: update error messages

### DIFF
--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -101,7 +101,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
       }
 
       if (token.client.id !== client.id) {
-        throw new InvalidGrantError('Invalid grant: refresh token is invalid');
+        throw new InvalidGrantError('Invalid grant: refresh token was issued to another client');
       }
 
       if (token.refreshTokenExpiresAt && !(token.refreshTokenExpiresAt instanceof Date)) {
@@ -130,7 +130,7 @@ RefreshTokenGrantType.prototype.revokeToken = function(token) {
   return promisify(this.model.revokeToken, 1).call(this.model, token)
     .then(function(status) {
       if (!status) {
-        throw new InvalidGrantError('Invalid grant: refresh token is invalid');
+        throw new InvalidGrantError('Invalid grant: refresh token is invalid or could not be revoked');
       }
 
       return token;

--- a/test/integration/grant-types/refresh-token-grant-type_test.js
+++ b/test/integration/grant-types/refresh-token-grant-type_test.js
@@ -262,7 +262,7 @@ describe('RefreshTokenGrantType integration', function() {
         .then(should.fail)
         .catch(function(e) {
           e.should.be.an.instanceOf(InvalidGrantError);
-          e.message.should.equal('Invalid grant: refresh token is invalid');
+          e.message.should.equal('Invalid grant: refresh token was issued to another client');
         });
     });
 
@@ -304,7 +304,7 @@ describe('RefreshTokenGrantType integration', function() {
         .then(should.fail)
         .catch(function(e) {
           e.should.be.an.instanceOf(InvalidGrantError);
-          e.message.should.equal('Invalid grant: refresh token is invalid');
+          e.message.should.equal('Invalid grant: refresh token was issued to another client');
         });
     });
 


### PR DESCRIPTION

## Summary
The main problem is various errors were identical in the Refresh Token Grant file. While working on an express/mongodb adapter I kept erroring out at the client check. Well the client check error is the same error that exist in like 5 other places. Just changing the verbiage alone would help in diagnosing the problem.


## Involved parts of the project
[https://github.com/node-oauth/node-oauth2-server/blob/master/lib/grant-types/refresh-token-grant-type.js](Refresh Grant Type)



## Added tests?
si



## OAuth2 standard
Its just the error verbiage the logic remains untouched.



## Reproduction
No new features just changing some text.

## old PR
https://github.com/node-oauth/node-oauth2-server/pull/140