### PR TITLE
Save code challenge with authorization code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -306,7 +306,7 @@ declare namespace OAuth2Server {
          *
          */
         saveAuthorizationCode(
-          code: Pick<AuthorizationCode, 'authorizationCode' | 'expiresAt' | 'redirectUri' | 'scope'>,
+          code: Pick<AuthorizationCode, 'authorizationCode' | 'expiresAt' | 'redirectUri' | 'scope' | 'codeChallenge' | 'codeChallengeMethod'>,
           client: Client,
           user: User,
           callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode | Falsey>;
@@ -410,6 +410,8 @@ declare namespace OAuth2Server {
         scope?: string | string[] | undefined;
         client: Client;
         user: User;
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
         [key: string]: any;
     }
 

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -296,14 +296,19 @@ AuthorizeHandler.prototype.getRedirectUri = function(request, client) {
  */
 
 AuthorizeHandler.prototype.saveAuthorizationCode = function(authorizationCode, expiresAt, scope, client, redirectUri, user, codeChallenge, codeChallengeMethod) {
-  const code = {
+  let code = {
     authorizationCode: authorizationCode,
     expiresAt: expiresAt,
     redirectUri: redirectUri,
-    scope: scope,
-    codeChallenge: codeChallenge,
-    codeChallengeMethod: codeChallengeMethod
+    scope: scope
   };
+
+  if(codeChallenge && codeChallengeMethod){
+    code = Object.assign({
+      codeChallenge: codeChallenge,
+      codeChallengeMethod: codeChallengeMethod
+    }, code);
+  }
   return promisify(this.model.saveAuthorizationCode, 3).call(this.model, code, client, user);
 };
 

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -114,8 +114,10 @@ AuthorizeHandler.prototype.handle = function(request, response) {
         })
         .then(function(authorizationCode) {
           ResponseType = this.getResponseType(request);
+          const codeChallenge = this.getCodeChallenge(request);
+          const codeChallengeMethod = this.getCodeChallengeMethod(request);
 
-          return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user);
+          return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user, codeChallenge, codeChallengeMethod);
         })
         .then(function(code) {
           const responseType = new ResponseType(code.authorizationCode);
@@ -293,12 +295,14 @@ AuthorizeHandler.prototype.getRedirectUri = function(request, client) {
  * Save authorization code.
  */
 
-AuthorizeHandler.prototype.saveAuthorizationCode = function(authorizationCode, expiresAt, scope, client, redirectUri, user) {
+AuthorizeHandler.prototype.saveAuthorizationCode = function(authorizationCode, expiresAt, scope, client, redirectUri, user, codeChallenge, codeChallengeMethod) {
   const code = {
     authorizationCode: authorizationCode,
     expiresAt: expiresAt,
     redirectUri: redirectUri,
-    scope: scope
+    scope: scope,
+    codeChallenge: codeChallenge,
+    codeChallengeMethod: codeChallengeMethod
   };
   return promisify(this.model.saveAuthorizationCode, 3).call(this.model, code, client, user);
 };
@@ -367,6 +371,14 @@ AuthorizeHandler.prototype.updateResponse = function(response, redirectUri, stat
   }
 
   response.redirect(url.format(redirectUri));
+};
+
+AuthorizeHandler.prototype.getCodeChallenge = function(request) {
+  return request.body.code_challenge || request.query.code_challenge;
+};
+
+AuthorizeHandler.prototype.getCodeChallengeMethod = function(request) {
+  return request.body.code_challenge_method || request.query.code_challenge_method;
 };
 
 /**

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -374,11 +374,15 @@ AuthorizeHandler.prototype.updateResponse = function(response, redirectUri, stat
 };
 
 AuthorizeHandler.prototype.getCodeChallenge = function(request) {
-  return request.body.code_challenge || request.query.code_challenge;
+  return request.body.code_challenge;
 };
 
+/**
+ * Get code challenge method from request or defaults to plain.
+ * https://www.rfc-editor.org/rfc/rfc7636#section-4.3
+ */
 AuthorizeHandler.prototype.getCodeChallengeMethod = function(request) {
-  return request.body.code_challenge_method || request.query.code_challenge_method;
+  return request.body.code_challenge_method || 'plain';
 };
 
 /**

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -1321,4 +1321,44 @@ describe('AuthorizeHandler integration', function() {
       response.get('location').should.equal('http://example.com/cb?state=foobar');
     });
   });
+
+  describe('getCodeChallengeMethod()', function() {
+    it('should get code challenge method', function() {
+      const model = {
+        getAccessToken: function() {},
+        getClient: function() {},
+        saveAuthorizationCode: function() {}
+      };
+      const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });      const request = new Request({ body: {code_challenge_method: 'S256'}, headers: {}, method: {}, query: {} });
+
+      const codeChallengeMethod  = handler.getCodeChallengeMethod(request);
+      codeChallengeMethod.should.equal('S256');
+    });
+
+    it('should get default code challenge method plain if missing', function() {
+      const model = {
+        getAccessToken: function() {},
+        getClient: function() {},
+        saveAuthorizationCode: function() {}
+      };
+      const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });      const request = new Request({ body: {}, headers: {}, method: {}, query: {} });
+
+      const codeChallengeMethod  = handler.getCodeChallengeMethod(request);
+      codeChallengeMethod.should.equal('plain');
+    });
+  });
+
+  describe('getCodeChallenge()', function() {
+    it('should get code challenge', function() {
+      const model = {
+        getAccessToken: function() {},
+        getClient: function() {},
+        saveAuthorizationCode: function() {}
+      };
+      const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });      const request = new Request({ body: {code_challenge: 'challenge'}, headers: {}, method: {}, query: {} });
+
+      const codeChallengeMethod  = handler.getCodeChallenge(request);
+      codeChallengeMethod.should.equal('challenge');
+    });
+  });
 });

--- a/test/unit/handlers/authorize-handler_test.js
+++ b/test/unit/handlers/authorize-handler_test.js
@@ -87,6 +87,26 @@ describe('AuthorizeHandler', function() {
       };
       const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
 
+      return handler.saveAuthorizationCode('foo', 'bar', 'qux', 'biz', 'baz', 'boz')
+        .then(function() {
+          model.saveAuthorizationCode.callCount.should.equal(1);
+          model.saveAuthorizationCode.firstCall.args.should.have.length(3);
+          model.saveAuthorizationCode.firstCall.args[0].should.eql({ authorizationCode: 'foo', expiresAt: 'bar', redirectUri: 'baz', scope: 'qux' });
+          model.saveAuthorizationCode.firstCall.args[1].should.equal('biz');
+          model.saveAuthorizationCode.firstCall.args[2].should.equal('boz');
+          model.saveAuthorizationCode.firstCall.thisValue.should.equal(model);
+        })
+        .catch(should.fail);
+    });
+
+    it('should call `model.saveAuthorizationCode()` with code challenge', function() {
+      const model = {
+        getAccessToken: function() {},
+        getClient: function() {},
+        saveAuthorizationCode: sinon.stub().returns({})
+      };
+      const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
+
       return handler.saveAuthorizationCode('foo', 'bar', 'qux', 'biz', 'baz', 'boz', 'codeChallenge', 'codeChallengeMethod')
         .then(function() {
           model.saveAuthorizationCode.callCount.should.equal(1);

--- a/test/unit/handlers/authorize-handler_test.js
+++ b/test/unit/handlers/authorize-handler_test.js
@@ -87,11 +87,11 @@ describe('AuthorizeHandler', function() {
       };
       const handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
 
-      return handler.saveAuthorizationCode('foo', 'bar', 'qux', 'biz', 'baz', 'boz')
+      return handler.saveAuthorizationCode('foo', 'bar', 'qux', 'biz', 'baz', 'boz', 'codeChallenge', 'codeChallengeMethod')
         .then(function() {
           model.saveAuthorizationCode.callCount.should.equal(1);
           model.saveAuthorizationCode.firstCall.args.should.have.length(3);
-          model.saveAuthorizationCode.firstCall.args[0].should.eql({ authorizationCode: 'foo', expiresAt: 'bar', redirectUri: 'baz', scope: 'qux' });
+          model.saveAuthorizationCode.firstCall.args[0].should.eql({ authorizationCode: 'foo', expiresAt: 'bar', redirectUri: 'baz', scope: 'qux', codeChallenge: 'codeChallenge', codeChallengeMethod: 'codeChallengeMethod' });
           model.saveAuthorizationCode.firstCall.args[1].should.equal('biz');
           model.saveAuthorizationCode.firstCall.args[2].should.equal('boz');
           model.saveAuthorizationCode.firstCall.thisValue.should.equal(model);


### PR DESCRIPTION
## Summary
For getAuthorizationCode it is expected that the code contains a codeChallenge and a codeChallengeMethod but in saveAuthorizationCode it is not saved.

By adding the possibility to save codeChallenge and codeChallengeMethod the PKCE flow now works without any other changes. 


## Linked issue(s)
https://github.com/node-oauth/node-oauth2-server/issues/76


## Involved parts of the project
Authorization Code Flow with PKCE


## Added tests?
Yes


## OAuth2 standard
 OAuth 2.0 RFC 7636

## Reproduction
First authorize
```
curl --location --request POST 'http://localhost:8081/oauth2/authorize' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'client_id=test' \
--data-urlencode 'scope=openid' \
--data-urlencode 'redirect_uri=http://localhost:5000/callback' \
--data-urlencode 'state=e3e96ed8-889d-4dac-a680-6a47f5efbb14' \
--data-urlencode 'response_type=code' \
--data-urlencode 'username=user@user.com' \
--data-urlencode 'password=password' \
--data-urlencode 'code_challenge=challenge' \
--data-urlencode 'code_challenge_method=plain'
```

Use code from redirect and create token by:
```
curl --location --request POST 'http://localhost:8081/oauth2/token' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'client_id=test' \
--data-urlencode 'grant_type=authorization_code' \
--data-urlencode 'state=e3e96ed8-889d-4dac-a680-6a47f5efbb14' \
--data-urlencode 'response_type=code' \
--data-urlencode 'code_verifier=challenge' \
--data-urlencode 'code_challenge_method=plain' \
--data-urlencode 'code=7590791f34ddd18b7cdc398eee673051397bde3230533cdc24bd472ee472be02' \
--data-urlencode 'redirect_uri=http://localhost:5000/callback'
```