### PR TITLE
Marked verifyScope function as optional in model types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,7 @@ declare namespace OAuth2Server {
 
         /**
          * Invoked during request authentication to check if the provided access token was authorized the requested scopes.
+         * Optional, if a custom authenticateHandler is used or if there is no scope part of the request.
          *
          */
         verifyScope?(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -279,7 +279,7 @@ declare namespace OAuth2Server {
          * Invoked during request authentication to check if the provided access token was authorized the requested scopes.
          *
          */
-        verifyScope(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;
+        verifyScope?(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;
     }
 
     interface AuthorizationCodeModel extends BaseModel, RequestAuthenticationModel {


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------- 

🎉 THANK YOU FOR YOUR CONTRIBUTION! 🎉

We highly appreciate your time and effort to this project!


⚠ PLEASE READ THIS FIRST ⚠

1. If this is a fix for a security vulnerability you discovered please don't 
just open this PR until we have privately discussed the vulnerability. Disclosing 
it without contacting us can lead to severe implications for many applications 
that run on this project.

2. Make sure you have read the contribution guidelines for this project in
order to raise the chance of getting your PR accepted. This saves you valuable 
time and effort.

3. The following structure is a basic guideline. If a section does not apply you
can remove it.
---------------------------------------------------------------------------- -->

## Summary
When you do not implement `verifyScope` method in the model, TypeScript currently throws an error even though you do not need to implement this method in all cases. There are a lot of instances where `verifyScope` method is optional. There is already some error mechanisms to throw errors in cases where `verifyScope` is required and is not implemented. So making this implementation optional in models.



## Linked issue(s)
https://github.com/node-oauth/node-oauth2-server/issues/202



## Involved parts of the project
Typings



## Added tests?
NA



## OAuth2 standard
NA



## Reproduction
TypeScript will not throw errors anymore if you do not implement `verifyScope` when using your own authenticate handler.
