### PR TITLE
Fixed `getUserFromClient` not being awaited in client credentials grant.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,7 @@ declare class OAuth2Server {
     authenticate(
         request: OAuth2Server.Request,
         response: OAuth2Server.Response,
-        options?: OAuth2Server.AuthenticateOptions,
-        callback?: OAuth2Server.Callback<OAuth2Server.Token>
+        options?: OAuth2Server.AuthenticateOptions
     ): Promise<OAuth2Server.Token>;
 
     /**
@@ -33,8 +32,7 @@ declare class OAuth2Server {
     authorize(
         request: OAuth2Server.Request,
         response: OAuth2Server.Response,
-        options?: OAuth2Server.AuthorizeOptions,
-        callback?: OAuth2Server.Callback<OAuth2Server.AuthorizationCode>
+        options?: OAuth2Server.AuthorizeOptions
     ): Promise<OAuth2Server.AuthorizationCode>;
 
     /**
@@ -43,8 +41,7 @@ declare class OAuth2Server {
     token(
         request: OAuth2Server.Request,
         response: OAuth2Server.Response,
-        options?: OAuth2Server.TokenOptions,
-        callback?: OAuth2Server.Callback<OAuth2Server.Token>
+        options?: OAuth2Server.TokenOptions
     ): Promise<OAuth2Server.Token>;
 }
 
@@ -239,11 +236,6 @@ declare namespace OAuth2Server {
     }
 
     /**
-     * Represents a generic callback structure for model callbacks
-     */
-    type Callback<T> = (err?: any, result?: T) => void;
-
-    /**
      * For returning falsey parameters in cases of failure
      */
     type Falsey = '' | 0 | false | null | undefined;
@@ -253,19 +245,19 @@ declare namespace OAuth2Server {
          * Invoked to generate a new access token.
          *
          */
-        generateAccessToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
+        generateAccessToken?(client: Client, user: User, scope: string | string[]): Promise<string>;
 
         /**
          * Invoked to retrieve a client using a client id or a client id/client secret combination, depending on the grant type.
          *
          */
-        getClient(clientId: string, clientSecret: string, callback?: Callback<Client | Falsey>): Promise<Client | Falsey>;
+        getClient(clientId: string, clientSecret: string): Promise<Client | Falsey>;
 
         /**
          * Invoked to save an access token and optionally a refresh token, depending on the grant type.
          *
          */
-        saveToken(token: Token, client: Client, user: User, callback?: Callback<Token>): Promise<Token | Falsey>;
+        saveToken(token: Token, client: Client, user: User): Promise<Token | Falsey>;
     }
 
     interface RequestAuthenticationModel {
@@ -273,13 +265,13 @@ declare namespace OAuth2Server {
          * Invoked to retrieve an existing access token previously saved through Model#saveToken().
          *
          */
-        getAccessToken(accessToken: string, callback?: Callback<Token>): Promise<Token | Falsey>;
+        getAccessToken(accessToken: string): Promise<Token | Falsey>;
 
         /**
          * Invoked during request authentication to check if the provided access token was authorized the requested scopes.
          *
          */
-        verifyScope(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;
+        verifyScope(token: Token, scope: string | string[]): Promise<boolean>;
     }
 
     interface AuthorizationCodeModel extends BaseModel, RequestAuthenticationModel {
@@ -287,19 +279,19 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[]): Promise<string>;
 
         /**
          * Invoked to generate a new authorization code.
          *
          */
-        generateAuthorizationCode?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
+        generateAuthorizationCode?(client: Client, user: User, scope: string | string[]): Promise<string>;
 
         /**
          * Invoked to retrieve an existing authorization code previously saved through Model#saveAuthorizationCode().
          *
          */
-        getAuthorizationCode(authorizationCode: string, callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode | Falsey>;
+        getAuthorizationCode(authorizationCode: string): Promise<AuthorizationCode | Falsey>;
 
         /**
          * Invoked to save an authorization code.
@@ -308,20 +300,20 @@ declare namespace OAuth2Server {
         saveAuthorizationCode(
           code: Pick<AuthorizationCode, 'authorizationCode' | 'expiresAt' | 'redirectUri' | 'scope' | 'codeChallenge' | 'codeChallengeMethod'>,
           client: Client,
-          user: User,
-          callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode | Falsey>;
+          user: User
+        ): Promise<AuthorizationCode | Falsey>;
 
         /**
          * Invoked to revoke an authorization code.
          *
          */
-        revokeAuthorizationCode(code: AuthorizationCode, callback?: Callback<boolean>): Promise<boolean>;
+        revokeAuthorizationCode(code: AuthorizationCode): Promise<boolean>;
 
         /**
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[]): Promise<string | string[] | Falsey>;
         
         /**
          * Invoked to check if the provided `redirectUri` is valid for a particular `client`.
@@ -335,19 +327,19 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[]): Promise<string>;
 
         /**
          * Invoked to retrieve a user using a username/password combination.
          *
          */
-        getUser(username: string, password: string, callback?: Callback<User | Falsey>): Promise<User | Falsey>;
+        getUser(username: string, password: string): Promise<User | Falsey>;
 
         /**
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[]): Promise<string | string[] | Falsey>;
     }
 
     interface RefreshTokenModel extends BaseModel, RequestAuthenticationModel {
@@ -355,19 +347,19 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[]): Promise<string>;
 
         /**
          * Invoked to retrieve an existing refresh token previously saved through Model#saveToken().
          *
          */
-        getRefreshToken(refreshToken: string, callback?: Callback<RefreshToken>): Promise<RefreshToken | Falsey>;
+        getRefreshToken(refreshToken: string): Promise<RefreshToken | Falsey>;
 
         /**
          * Invoked to revoke a refresh token.
          *
          */
-        revokeToken(token: RefreshToken | Token, callback?: Callback<boolean>): Promise<boolean>;
+        revokeToken(token: RefreshToken | Token): Promise<boolean>;
     }
 
     interface ClientCredentialsModel extends BaseModel, RequestAuthenticationModel {
@@ -375,13 +367,13 @@ declare namespace OAuth2Server {
          * Invoked to retrieve the user associated with the specified client.
          *
          */
-        getUserFromClient(client: Client, callback?: Callback<User | Falsey>): Promise<User | Falsey>;
+        getUserFromClient(client: Client): Promise<User | Falsey>;
 
         /**
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[]): Promise<string | string[] | Falsey>;
     }
 
     interface ExtensionModel extends BaseModel, RequestAuthenticationModel {}

--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -45,7 +45,7 @@ class ClientCredentialsGrantType extends AbstractGrantType {
     }
 
     const scope = this.getScope(request);
-    const user = this.getUserFromClient(client);
+    const user = await this.getUserFromClient(client);
 
     return this.saveToken(user, client, scope);
   }

--- a/test/integration/grant-types/client-credentials-grant-type_test.js
+++ b/test/integration/grant-types/client-credentials-grant-type_test.js
@@ -93,14 +93,21 @@ describe('ClientCredentialsGrantType integration', function() {
     it('should return a token', function() {
       const token = {};
       const model = {
-        getUserFromClient: function() { return {}; },
-        saveToken: function() { return token; },
+        getUserFromClient: async function(client) {
+          client.foo.should.equal('bar');
+          return { id: '123'};
+        },
+        saveToken: async function(_token, client, user) {
+          client.foo.should.equal('bar');
+          user.id.should.equal('123');
+          return token;
+        },
         validateScope: function() { return 'foo'; }
       };
       const grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 120, model: model });
       const request = new Request({ body: {}, headers: {}, method: {}, query: {} });
 
-      return grantType.handle(request, {})
+      return grantType.handle(request, { foo: 'bar' })
         .then(function(data) {
           data.should.equal(token);
         })


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------- 

🎉 THANK YOU FOR YOUR CONTRIBUTION! 🎉

We highly appreciate your time and effort to this project!


⚠ PLEASE READ THIS FIRST ⚠

1. If this is a fix for a security vulnerability you discovered please don't 
just open this PR until we have privately discussed the vulnerability. Disclosing 
it without contacting us can lead to severe implications for many applications 
that run on this project.

2. Make sure you have read the contribution guidelines for this project in
order to raise the chance of getting your PR accepted. This saves you valuable 
time and effort.

3. The following structure is a basic guideline. If a section does not apply you
can remove it.
---------------------------------------------------------------------------- -->

## Summary

`getUserFromClient` was not awaited in client credentials grant, this results in a promise being passed to the `validateScope` function in the model instead of the actual user.


## Linked issue(s)
#217 217



## Involved parts of the project
Client Credentials grant



## Added tests?
NA



## OAuth2 standard
<!-- ---------------------------------------------------------------------------
⚠ This section is important in order to review compliance with the standard(s).
Please refer to the standard if your PR affects any functionality or is 
otherwise related to the standard(s) in any way
---------------------------------------------------------------------------- -->



## Reproduction
<!-- ---------------------------------------------------------------------------
⚠ How can we reproduce your changes in an app? This is especially important
when new features are added
---------------------------------------------------------------------------- -->

