### PR TITLE
Convert Request, Response, CodeResponseType, TokenResponseType to ES6 classes

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -52,11 +52,7 @@ class Request {
    * @param {...String|Array} types
    */
   is(...types) {
-    if (types.length === 1 && Array.isArray(types[0])) {
-      types = types[0];
-    }
-
-    return typeis(this, types) || false;
+    return typeis(this, types.flat()) || false;
   }
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,67 +7,57 @@
 const InvalidArgumentError = require('./errors/invalid-argument-error');
 const typeis = require('type-is');
 
-/**
- * Constructor.
- */
-
-function Request(options) {
-  options = options || {};
-
-  if (!options.headers) {
-    throw new InvalidArgumentError('Missing parameter: `headers`');
-  }
-
-  if (!options.method) {
-    throw new InvalidArgumentError('Missing parameter: `method`');
-  }
-
-  if (!options.query) {
-    throw new InvalidArgumentError('Missing parameter: `query`');
-  }
-
-  this.body = options.body || {};
-  this.headers = {};
-  this.method = options.method;
-  this.query = options.query;
-
-  // Store the headers in lower case.
-  for (const field in options.headers) {
-    if (Object.prototype.hasOwnProperty.call(options.headers, field)) {
-      this.headers[field.toLowerCase()] = options.headers[field];
+class Request {
+  constructor({ headers, method, query, body, ...otherOptions } = {}) {
+    if (!headers) {
+      throw new InvalidArgumentError('Missing parameter: `headers`');
     }
+
+    if (!method) {
+      throw new InvalidArgumentError('Missing parameter: `method`');
+    }
+
+    if (!query) {
+      throw new InvalidArgumentError('Missing parameter: `query`');
+    }
+
+    this.body = body || {};
+    this.headers = {};
+    this.method = method;
+    this.query = query;
+
+    // Store the headers in lower case.
+    Object.entries(headers).forEach(([header, value]) => {
+      this.headers[header.toLowerCase()] = value;
+    });
+
+    // Store additional properties of the request object passed in
+    Object.entries(otherOptions)
+      .filter(([property]) => !this[property])
+      .forEach(([property, value]) => {
+        this[property] = value;
+      });
   }
 
-  // Store additional properties of the request object passed in
-  for (const property in options) {
-    if (Object.prototype.hasOwnProperty.call(options, property) && !this[property]) {
-      this[property] = options[property];
+  /**
+   * Get a request header.
+   * @param {String} field
+   */
+  get(field) {
+    return this.headers[field.toLowerCase()];
+  }
+
+  /**
+   * Check if the content-type matches any of the given mime types.
+   * @param {...String|Array} types
+   */
+  is(...types) {
+    if (types.length === 1 && Array.isArray(types[0])) {
+      types = types[0];
     }
+
+    return typeis(this, types) || false;
   }
 }
-
-/**
- * Get a request header.
- */
-
-Request.prototype.get = function(field) {
-  return this.headers[field.toLowerCase()];
-};
-
-/**
- * Check if the content-type matches any of the given mime type.
- */
-
-Request.prototype.is = function(types) {
-  if (!Array.isArray(types)) {
-    types = [].slice.call(arguments);
-  }
-
-  return typeis(this, types) || false;
-};
-
-/**
- * Export constructor.
- */
 
 module.exports = Request;

--- a/lib/response-types/code-response-type.js
+++ b/lib/response-types/code-response-type.js
@@ -7,37 +7,27 @@
 const InvalidArgumentError = require('../errors/invalid-argument-error');
 const url = require('url');
 
-/**
- * Constructor.
- */
+class CodeResponseType {
+  constructor(code) {
+    if (!code) {
+      throw new InvalidArgumentError('Missing parameter: `code`');
+    }
 
-function CodeResponseType(code) {
-  if (!code) {
-    throw new InvalidArgumentError('Missing parameter: `code`');
+    this.code = code;
   }
 
-  this.code = code;
+  buildRedirectUri(redirectUri) {
+    if (!redirectUri) {
+      throw new InvalidArgumentError('Missing parameter: `redirectUri`');
+    }
+
+    const uri = url.parse(redirectUri, true);
+
+    uri.query.code = this.code;
+    uri.search = null;
+
+    return uri;
+  }
 }
-
-/**
- * Build redirect uri.
- */
-
-CodeResponseType.prototype.buildRedirectUri = function(redirectUri) {
-  if (!redirectUri) {
-    throw new InvalidArgumentError('Missing parameter: `redirectUri`');
-  }
-
-  const uri = url.parse(redirectUri, true);
-
-  uri.query.code = this.code;
-  uri.search = null;
-
-  return uri;
-};
-
-/**
- * Export constructor.
- */
 
 module.exports = CodeResponseType;

--- a/lib/response-types/token-response-type.js
+++ b/lib/response-types/token-response-type.js
@@ -6,16 +6,10 @@
 
 const ServerError = require('../errors/server-error');
 
-/**
- * Constructor.
- */
-
-function TokenResponseType() {
-  throw new ServerError('Not implemented.');
+class TokenResponseType {
+  constructor() {
+    throw new ServerError('Not implemented.');
+  }
 }
-
-/**
- * Export constructor.
- */
 
 module.exports = TokenResponseType;

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,58 +1,45 @@
 'use strict';
 
-/**
- * Constructor.
- */
+class Response {
+  constructor({ headers = {}, body = {}, ...otherOptions } = {}) {
+    this.status = 200;
+    this.body = body;
+    this.headers = {};
 
-function Response(options) {
-  options = options || {};
+    // Store the headers in lower case.
+    Object.entries(headers).forEach(([header, value]) => {
+      this.headers[header.toLowerCase()] = value;
+    });
 
-  this.body = options.body || {};
-  this.headers = {};
-  this.status = 200;
-
-  // Store the headers in lower case.
-  for (const field in options.headers) {
-    if (Object.prototype.hasOwnProperty.call(options.headers, field)) {
-      this.headers[field.toLowerCase()] = options.headers[field];
-    }
+    // Store additional properties of the response object passed in
+    Object.entries(otherOptions)
+      .filter(([property]) => !this[property])
+      .forEach(([property, value]) => {
+        this[property] = value;
+      });
   }
 
-  // Store additional properties of the response object passed in
-  for (const property in options) {
-    if (Object.prototype.hasOwnProperty.call(options, property) && !this[property]) {
-      this[property] = options[property];
-    }
+  /**
+   * Get a response header.
+   */
+  get(field) {
+    return this.headers[field.toLowerCase()];
+  }
+
+  /**
+   * Redirect response.
+   */
+  redirect(url) {
+    this.set('Location', url);
+    this.status = 302;
+  }
+
+  /**
+   * Set a response header.
+   */
+  set(field, value) {
+    this.headers[field.toLowerCase()] = value;
   }
 }
-
-/**
- * Get a response header.
- */
-
-Response.prototype.get = function(field) {
-  return this.headers[field.toLowerCase()];
-};
-
-/**
- * Redirect response.
- */
-
-Response.prototype.redirect = function(url) {
-  this.set('Location', url);
-  this.status = 302;
-};
-
-/**
- * Set a response header.
- */
-
-Response.prototype.set = function(field, value) {
-  this.headers[field.toLowerCase()] = value;
-};
-
-/**
- * Export constructor.
- */
 
 module.exports = Response;

--- a/test/unit/request_test.js
+++ b/test/unit/request_test.js
@@ -127,6 +127,22 @@ describe('Request', function() {
     request.custom2.should.eql(originalRequest.custom2);
   });
 
+  it('should not allow overwriting methods on the Request prototype via custom properties', () => {
+    const request = new Request({
+      query: {},
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json'
+      },
+      get() {
+        // malicious attempt to override the 'get' method
+        return 'text/html';
+      }
+    });
+
+    request.get('content-type').should.equal('application/json');
+  });
+
   it('should allow getting of headers using `request.get`', function() {
     const originalRequest = generateBaseRequest();
 

--- a/test/unit/response_test.js
+++ b/test/unit/response_test.js
@@ -83,6 +83,20 @@ describe('Request', function() {
     response.custom2.should.eql(originalResponse.custom2);
   });
 
+  it('should not allow overwriting methods on the Response prototype via custom properties', () => {
+    const response = new Response({
+      headers: {
+        'content-type': 'application/json'
+      },
+      get() {
+        // malicious attempt to override the 'get' method
+        return 'text/html';
+      }
+    });
+
+    response.get('content-type').should.equal('application/json');
+  });
+
   it('should allow getting of headers using `response.get`', function() {
     const originalResponse = generateBaseResponse();
 


### PR DESCRIPTION
## Summary

Chipping away at #212 by converting four more classes:
- Request
- Response
- CodeResponseType
- TokenResponseType

(Do note that TokenResponseType's constructor simply throws a not implemented error, though. So that conversion was easy. 😉)

## Linked issue(s)
A few checkboxes of #212 (but not the whole thing).

## Involved parts of the project

Specifically the classes noted above, which affect pretty much everything (since Request/Response are core parts of the interface). But, there are no functional changes.

## Added tests?

I did not update the tests, but these files are already covered under the existing tests, which should continue to pass after this refactoring.

## OAuth2 standard

N/A

## Reproduction

N/A