### PR TITLE
Support for retrieving user based on client

### DIFF
--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -441,7 +441,7 @@ The return value (``client``) can carry additional properties that will be ignor
 
 .. _Model#getUser:
 
-``getUser(username, password)``
+``getUser(username, password, client)``
 ===========================================
 
 Invoked to retrieve a user using a username/password combination.
@@ -454,13 +454,15 @@ This model function is **required** if the ``password`` grant is used.
 
 **Arguments:**
 
-+------------+----------+---------------------------------------------------------------------+
-| Name       | Type     | Description                                                         |
-+============+==========+=====================================================================+
-| username   | String   | The username of the user to retrieve.                               |
-+------------+----------+---------------------------------------------------------------------+
-| password   | String   | The user's password.                                                |
-+------------+----------+---------------------------------------------------------------------+
++-------------------+----------+---------------------------------------------------------------------+
+| Name              | Type     | Description                                                         |
++===================+==========+=====================================================================+
+| username          | String   | The username of the user to retrieve.                               |
++-------------------+----------+---------------------------------------------------------------------+
+| password          | String   | The user's password.                                                |
++-------------------+----------+---------------------------------------------------------------------+
+| client (optional) | Client   | The user's password.                                                |
++-------------------+----------+---------------------------------------------------------------------+
 
 **Return value:**
 

--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -461,7 +461,7 @@ This model function is **required** if the ``password`` grant is used.
 +-------------------+----------+---------------------------------------------------------------------+
 | password          | String   | The user's password.                                                |
 +-------------------+----------+---------------------------------------------------------------------+
-| client (optional) | Client   | The user's password.                                                |
+| client (optional) | Client   | The client.                                                |
 +-------------------+----------+---------------------------------------------------------------------+
 
 **Return value:**

--- a/index.d.ts
+++ b/index.d.ts
@@ -334,7 +334,7 @@ declare namespace OAuth2Server {
          * Invoked to retrieve a user using a username/password combination.
          *
          */
-        getUser(username: string, password: string): Promise<User | Falsey>;
+        getUser(username: string, password: string, client: Client): Promise<User | Falsey>;
 
         /**
          * Invoked to check if the requested scope is valid for a particular client/user combination.

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -47,7 +47,7 @@ class PasswordGrantType extends AbstractGrantType {
     }
 
     const scope = this.getScope(request);
-    const user = await this.getUser(request);
+    const user = await this.getUser(request, client);
 
     return this.saveToken(user, client, scope);
   }
@@ -56,7 +56,7 @@ class PasswordGrantType extends AbstractGrantType {
 	 * Get user using a username/password combination.
 	 */
 
-  async getUser(request) {
+  async getUser(request, client) {
     if (!request.body.username) {
       throw new InvalidRequestError('Missing parameter: `username`');
     }
@@ -73,7 +73,7 @@ class PasswordGrantType extends AbstractGrantType {
       throw new InvalidRequestError('Invalid parameter: `password`');
     }
 
-    const user = await this.model.getUser(request.body.username, request.body.password);
+    const user = await this.model.getUser(request.body.username, request.body.password, client);
 
     if (!user) {
       throw new InvalidGrantError('Invalid grant: user credentials are invalid');

--- a/test/integration/grant-types/password-grant-type_test.js
+++ b/test/integration/grant-types/password-grant-type_test.js
@@ -177,11 +177,12 @@ describe('PasswordGrantType integration', function() {
         getUser: () => should.fail(),
         saveToken: () => should.fail()
       };
+      const client = { id: 'foobar' };
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: {}, headers: {}, method: {}, query: {} });
 
       try {
-        await grantType.getUser(request);
+        await grantType.getUser(request, client);
 
         should.fail();
       } catch (e) {
@@ -195,11 +196,12 @@ describe('PasswordGrantType integration', function() {
         getUser: () => should.fail(),
         saveToken: () => should.fail()
       };
+      const client = { id: 'foobar' };
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foo' }, headers: {}, method: {}, query: {} });
 
       try {
-        await grantType.getUser(request);
+        await grantType.getUser(request, client);
 
         should.fail();
       } catch (e) {
@@ -213,11 +215,12 @@ describe('PasswordGrantType integration', function() {
         getUser: () => should.fail(),
         saveToken: () => should.fail()
       };
+      const client = { id: 'foobar' };
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: '\r\n', password: 'foobar' }, headers: {}, method: {}, query: {} });
 
       try {
-        await grantType.getUser(request);
+        await grantType.getUser(request, client);
 
         should.fail();
       } catch (e) {
@@ -231,11 +234,12 @@ describe('PasswordGrantType integration', function() {
         getUser: () => should.fail(),
         saveToken: () => should.fail()
       };
+      const client = { id: 'foobar' };
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foobar', password: '\r\n' }, headers: {}, method: {}, query: {} });
 
       try {
-        await grantType.getUser(request);
+        await grantType.getUser(request, client);
 
         should.fail();
       } catch (e) {
@@ -249,11 +253,12 @@ describe('PasswordGrantType integration', function() {
         getUser: async () => undefined,
         saveToken: () => should.fail()
       };
+      const client = { id: 'foobar' };
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
 
       try {
-        await grantType.getUser(request);
+        await grantType.getUser(request, client);
         should.fail();
       } catch (e) {
         e.should.be.an.instanceOf(InvalidGrantError);
@@ -263,6 +268,7 @@ describe('PasswordGrantType integration', function() {
 
     it('should return a user', async function() {
       const user = { email: 'foo@bar.com' };
+      const client = { id: 'foobar' };
       const model = {
         getUser: function(username, password) {
           username.should.equal('foo');
@@ -274,12 +280,13 @@ describe('PasswordGrantType integration', function() {
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
 
-      const data = await grantType.getUser(request);
+      const data = await grantType.getUser(request, client);
       data.should.equal(user);
     });
 
     it('should support promises', function() {
       const user = { email: 'foo@bar.com' };
+      const client = { id: 'foobar' };
       const model = {
         getUser: async function() { return user; },
         saveToken: () => should.fail()
@@ -287,11 +294,12 @@ describe('PasswordGrantType integration', function() {
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
 
-      grantType.getUser(request).should.be.an.instanceOf(Promise);
+      grantType.getUser(request, client).should.be.an.instanceOf(Promise);
     });
 
     it('should support non-promises', function() {
       const user = { email: 'foo@bar.com' };
+      const client = { id: 'foobar' };
       const model = {
         getUser: function() { return user; },
         saveToken: () => should.fail()
@@ -299,7 +307,7 @@ describe('PasswordGrantType integration', function() {
       const grantType = new PasswordGrantType({ accessTokenLifetime: 123, model });
       const request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
 
-      grantType.getUser(request).should.be.an.instanceOf(Promise);
+      grantType.getUser(request, client).should.be.an.instanceOf(Promise);
     });
   });
 

--- a/test/unit/grant-types/password-grant-type_test.js
+++ b/test/unit/grant-types/password-grant-type_test.js
@@ -20,13 +20,14 @@ describe('PasswordGrantType', function() {
         getUser: sinon.stub().returns(true),
         saveToken: function() {}
       };
+      const client = { id: 'foobar' };
       const handler = new PasswordGrantType({ accessTokenLifetime: 120, model: model });
       const request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
 
-      return handler.getUser(request)
+      return handler.getUser(request, client)
         .then(function() {
           model.getUser.callCount.should.equal(1);
-          model.getUser.firstCall.args.should.have.length(2);
+          model.getUser.firstCall.args.should.have.length(3);
           model.getUser.firstCall.args[0].should.equal('foo');
           model.getUser.firstCall.args[1].should.equal('bar');
           model.getUser.firstCall.thisValue.should.equal(model);


### PR DESCRIPTION
## Summary
<!-- ---------------------------------------------------------------------------
⚠ Provide one or two paragraphs
---------------------------------------------------------------------------- -->

Pass the client to the `getUser` function of the model. This makes it possible to retrieve the user based on the client.

## Linked issue(s)
<!-- ---------------------------------------------------------------------------
⚠ If there is no issue for this PR we won't review it
---------------------------------------------------------------------------- -->

#114 

## Involved parts of the project
<!-- ---------------------------------------------------------------------------
⚠ Which parts of the code is affected and which OAuth2 workflows are involved
---------------------------------------------------------------------------- -->

Password Grant Type

## Added tests?
<!-- ---------------------------------------------------------------------------
⚠ Did you add tests that cover your changes?
---------------------------------------------------------------------------- -->

Yes
