### PR TITLE
fix: update typing for validateScope making scope an optional parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ declare namespace OAuth2Server {
          * Validate requested scope. Calls Model#validateScope() if implemented.
          *
          */
-        validateScope(user: User, client: Client, scope: string[]): Promise<string[] | Falsey>;
+        validateScope(user: User, client: Client, scope?: string[]): Promise<string[] | Falsey>;
 
         /**
          * Retrieve info from the request and client and return token
@@ -314,7 +314,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string[]): Promise<string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope?: string[]): Promise<string[] | Falsey>;
 
         /**
          * Invoked to check if the provided `redirectUri` is valid for a particular `client`.
@@ -340,7 +340,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string[]): Promise<string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope?: string[]): Promise<string[] | Falsey>;
     }
 
     interface RefreshTokenModel extends BaseModel, RequestAuthenticationModel {
@@ -374,7 +374,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string[]): Promise<string[] | Falsey>;
+        validateScope?(user: User, client: Client, scope?: string[]): Promise<string[] | Falsey>;
     }
 
     interface ExtensionModel extends BaseModel, RequestAuthenticationModel {}


### PR DESCRIPTION
## Summary

If a request is received with no scope in the request body, then the `scope` argument to `validateScope` is undefined instead of an array. This change updates the typings to be consistent with that behaviour.

## Linked issue(s)

resolves #264

## Involved parts of the project

https://github.com/node-oauth/node-oauth2-server/blob/v5.0.0/lib/utils/scope-util.js#L10-L12



## Added tests?

n/a

## OAuth2 standard

n/a



## Reproduction

See issue.
