### PR TITLE
fix: explicitly support array of strings for AuthenticateHandler.options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -168,7 +168,7 @@ declare namespace OAuth2Server {
         /**
          * The scope(s) to authenticate.
          */
-        scope?: string | undefined;
+        scope?: string[];
 
         /**
          * Set the X-Accepted-OAuth-Scopes HTTP header on response objects.

--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -47,7 +47,7 @@ class AuthenticateHandler {
     this.addAuthorizedScopesHeader = options.addAuthorizedScopesHeader;
     this.allowBearerTokensInQueryString = options.allowBearerTokensInQueryString;
     this.model = options.model;
-    this.scope = parseScope(options.scope);
+    this.scope = Array.isArray(options.scope) ? options.scope : parseScope(options.scope);
   }
 
   /**


### PR DESCRIPTION
## Summary

In #267 some changes were made for compliance reasons where scopes should be treated as strings for our OAuth interfaces but as arrays of strings for internal purposes. As part of that change, we accidentally made the `scope` prop for the `authenticate` method only support strings.

This change remediates any potential backwards compatibility changes from v5.0 to v5.1

## Linked issue(s)

#307 & #267 



## Involved parts of the project

authenticate handler

## Added tests?

✅ 

