### PR TITLE
perf: random tokens do not need to be hashed

### DIFF
--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -5,7 +5,6 @@
  */
 
 const randomBytes = require('crypto').randomBytes;
-const { createHash } = require('../utils/crypto-util');
 
 /**
  * Export `TokenUtil`.
@@ -17,8 +16,15 @@ module.exports = {
    * Generate random token.
    */
 
-  generateRandomToken: async function() {
-    const buffer = randomBytes(256);
-    return createHash({ data: buffer, encoding: 'hex' });
+  generateRandomToken: function() {
+    return new Promise((resolve, reject) => {
+      randomBytes(32, (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data.toString('hex'));
+        }
+      });
+    });
   }
 };


### PR DESCRIPTION
There are some wasted CPU cycles when generating the random tokens.

There's no need to generate extra random bytes only to hash them. A random input will lead to a random hash being generated, but the random input is enough in its own right and does not need to be hashed to make it any more or less secure. The amount of entropy is capped at 32 bytes when hashed, so we may as well just provide 32 random bytes.

As an added bonus, this also returns the method to a true non-blocking async function.