### PR TITLE
Always set error information on the response within AuthorizeHandler

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -79,13 +79,14 @@ class  AuthorizeHandler {
     }
 
     const expiresAt = await this.getAuthorizationCodeLifetime();
-    const client = await this.getClient(request);
-    const user = await this.getUser(request, response);
 
     let uri;
     let state;
 
     try {
+      const client = await this.getClient(request);
+      const user = await this.getUser(request, response);
+  
       uri = this.getRedirectUri(request, client);
       state = this.getState(request);
 


### PR DESCRIPTION
## Summary

Both `AuthorizeHandler.getClient` and `AuthorizeHandler.getUser` can throw exceptions, including due to invalid client input (e.g. a `redirect_uri` mismatch). These exceptions must be caught, so the response can be updated with the appropriate error information before the exception is re-thrown.

In all other error conditions, `AuthorizeHandler.handle` already sets error information on the response before re-throwing the exception.
