### PR TITLE
feat: add assertion framework support to client authentication

### DIFF
--- a/docs/api/handlers/token-handler.md
+++ b/docs/api/handlers/token-handler.md
@@ -53,8 +53,14 @@ Get client credentials.
 The client credentials may be sent using the HTTP Basic authentication scheme or, alternatively,
 the `client_id` and `client_secret` can be embedded in the body.
 
+Also support the assertion framework for client authentication.
+
 **Kind**: instance method of [<code>TokenHandler</code>](#TokenHandler)  
-**See**: https://tools.ietf.org/html/rfc6749#section-2.3.1  
+**See**
+
+- https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
+- https://datatracker.ietf.org/doc/html/rfc7521
+
 <a name="TokenHandler+handleGrantType"></a>
 
 ### tokenHandler.handleGrantType()

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,6 +210,16 @@ declare namespace OAuth2Server {
         authorizationCodeLifetime?: number;
     }
 
+    interface TokenRequest {
+        grant_type: string;
+        client_assertion?: string;
+        client_assertion_type?: string;
+        client_id?: string;
+        client_secret?: string;
+        code_verifier?: string;
+        scope?: string;
+    }
+
     interface TokenOptions {
         /**
          * Lifetime of generated access tokens in seconds (default = 1 hour)
@@ -243,6 +253,11 @@ declare namespace OAuth2Server {
          * Additional supported grant types.
          */
         extendedGrantTypes?: Record<string, typeof AbstractGrantType>;
+
+        /**
+         * Request processor
+         */
+        requestProcessor?: ((request: Request) => TokenRequest)
     }
 
     interface AssertionCredential {

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,6 +245,12 @@ declare namespace OAuth2Server {
         extendedGrantTypes?: Record<string, typeof AbstractGrantType>;
     }
 
+    interface AssertionCredential {
+        clientAssertion: string;
+        clientAssertionType: string;
+        clientId?: string;
+    }
+
     /**
      * For returning falsey parameters in cases of failure
      */
@@ -268,6 +274,16 @@ declare namespace OAuth2Server {
          *
          */
         saveToken(token: Omit<Token, 'client' | 'user'>, client: Client, user: User): Promise<Token | Falsey>;
+
+        /**
+         * Invoked to retrieve a client using a client assertion.
+         *
+         * It is for the model to decide if it supports the assertion framework and, if so, which
+         * assertion frameworks are supported. The function can return null if no model is found or
+         * throw an `InvalidClientError` if the assertion is invalid or not supported.
+         *
+         */
+        getClientFromAssertion?(assertion: AssertionCredential): Promise<Client | Falsey>;
     }
 
     interface RequestAuthenticationModel {

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -62,6 +62,7 @@ class TokenHandler {
     this.requireClientAuthentication = options.requireClientAuthentication || {};
     this.alwaysIssueNewRefreshToken = options.alwaysIssueNewRefreshToken !== false;
     this.enablePlainPKCE = options.enablePlainPKCE === true;
+    this.requestProcessor = options.requestProcessor;
   }
 
   /**
@@ -86,8 +87,13 @@ class TokenHandler {
     }
 
     try {
-      const client = await this.getClient(request, response);
-      const data = await this.handleGrantType(request, client);
+      const body = this.requestProcessor?.(request) ?? request.body;
+      const req = new Request({
+        ...request,
+        body,
+      });
+      const client = await this.getClient(req, response);
+      const data = await this.handleGrantType(req, client);
       const model = new TokenModel(data, {
         allowExtendedTokenAttributes: this.allowExtendedTokenAttributes,
       });
@@ -146,7 +152,9 @@ class TokenHandler {
     }
 
     try {
-      const client = await (isAssertion ? this.model.getClientFromAssertion?.(credentials) : this.model.getClient(credentials.clientId, credentials.clientSecret));
+      const client = await (isAssertion
+        ? this.model.getClientFromAssertion?.(credentials)
+        : this.model.getClient(credentials.clientId, credentials.clientSecret));
 
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
@@ -204,7 +212,11 @@ class TokenHandler {
     }
 
     if (this.isClientAssertionRequest(request)) {
-      return { clientId: request.body.client_id, clientAssertion: request.body.client_assertion, clientAssertionType: request.body.client_assertion_type };
+      return {
+        clientId: request.body.client_id,
+        clientAssertion: request.body.client_assertion,
+        clientAssertionType: request.body.client_assertion_type,
+      };
     }
 
     if (pkce.isPKCERequest({ grantType, codeVerifier })) {

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -117,25 +117,36 @@ class TokenHandler {
     const grantType = request.body.grant_type;
     const codeVerifier = request.body.code_verifier;
     const isPkce = pkce.isPKCERequest({ grantType, codeVerifier });
+    const isAssertion = this.isClientAssertionRequest(request);
 
-    if (!credentials.clientId) {
-      throw new InvalidRequestError('Missing parameter: `client_id`');
-    }
+    // @todo - if multiple authentication schemes exist, throw an error
+    if (!isAssertion) {
+      if (!credentials.clientId) {
+        throw new InvalidRequestError('Missing parameter: `client_id`');
+      }
 
-    if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret && !isPkce) {
-      throw new InvalidRequestError('Missing parameter: `client_secret`');
-    }
+      if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret && !isPkce) {
+        throw new InvalidRequestError('Missing parameter: `client_secret`');
+      }
 
-    if (!isFormat.vschar(credentials.clientId)) {
-      throw new InvalidRequestError('Invalid parameter: `client_id`');
-    }
+      if (!isFormat.vschar(credentials.clientId)) {
+        throw new InvalidRequestError('Invalid parameter: `client_id`');
+      }
 
-    if (credentials.clientSecret && !isFormat.vschar(credentials.clientSecret)) {
-      throw new InvalidRequestError('Invalid parameter: `client_secret`');
+      if (credentials.clientSecret && !isFormat.vschar(credentials.clientSecret)) {
+        throw new InvalidRequestError('Invalid parameter: `client_secret`');
+      }
+    } else {
+      if (!credentials.clientAssertion) {
+        throw new InvalidClientError('Missing parameter: `client_assertion`');
+      }
+      if (!credentials.clientAssertionType) {
+        throw new InvalidClientError('Missing parameter: `client_assertion_type`');
+      }
     }
 
     try {
-      const client = await this.model.getClient(credentials.clientId, credentials.clientSecret);
+      const client = await (isAssertion ? this.model.getClientFromAssertion?.(credentials) : this.model.getClient(credentials.clientId, credentials.clientSecret));
 
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
@@ -170,7 +181,10 @@ class TokenHandler {
    * The client credentials may be sent using the HTTP Basic authentication scheme or, alternatively,
    * the `client_id` and `client_secret` can be embedded in the body.
    *
-   * @see https://tools.ietf.org/html/rfc6749#section-2.3.1
+   * Also support the assertion framework for client authentication.
+   *
+   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
+   * @see https://datatracker.ietf.org/doc/html/rfc7521
    */
 
   getClientCredentials(request) {
@@ -187,6 +201,10 @@ class TokenHandler {
         clientId: request.body.client_id,
         clientSecret: request.body.client_secret,
       };
+    }
+
+    if (this.isClientAssertionRequest(request)) {
+      return { clientId: request.body.client_id, clientAssertion: request.body.client_assertion, clientAssertionType: request.body.client_assertion_type };
     }
 
     if (pkce.isPKCERequest({ grantType, codeVerifier })) {
@@ -300,6 +318,10 @@ class TokenHandler {
     };
 
     response.status = error.code;
+  }
+
+  isClientAssertionRequest({ body }) {
+    return body.client_assertion && body.client_assertion_type;
   }
 
   /**


### PR DESCRIPTION
## Summary

I'm looking to implement client assertion support. At the moment I'm leaning to keeping as much of this in
user-land code, but maybe we should have a way to register client authentication plugins (in a similar way that
we do with grant types). I think that might take quite a refactor (and breaking changes) to allow for that.

At the moment this is just a draft to check what the minimum interface is to get this working in user-land.

---

Some way to inject a body parser/interpreter is needed because the assertions contain most of the relevant request data that is typically just a property in the request body and most of the library makes an assumption that all the data is props in the body.

## Linked issue(s)

N/A

## Involved parts of the project

Client authentication

## Added tests?

todo

## OAuth2 standard

- [Assertion Framework for OAuth 2.0 Client Authentication Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7521)
- [JWT profile for OAuth 2.0 Client Authentication and Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523)


## Example

This would be implemented something like this to support client assertions with JWT:


getting a token:

```ts
        const token = await server.token(request, response, {
            requestProcessor: (incoming: OAuth2Server.Request) => {
                // determine if this is a request we can process (ie: a client assertion)
                if (isClientAssertionRequest(incoming)) {
                    // just read out the JWT data - this isn't being verified as genuine at this point, that comes later - we just want to know who this request is *claiming* to be.
                    const { scope, sub: client_id } = decodeJwt<{ scope?: string }>(incoming.body.client_assertion);
                    return {
                        client_id,
                        client_assertion: incoming.body.client_assertion,
                        client_assertion_type: incoming.body.client_assertion_type,
                        grant_type: incoming.body.grant_type,
                        code_verifier: incoming.body.code_verifier,
                        scope,
                    };
                }
                return incoming.body as TokenRequest;
            },
        });
```

Implementing getClientFromAssertion:

```ts
    async getClientFromAssertion(assertion: OAuth2Server.AssertionCredential): Promise<OAuth2Server.Client | OAuth2Server.Falsey> {
        // verify we can handle this assertion type
        if (assertion.clientAssertionType !== 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer') {
            throw new InvalidClientError('client_assertion_type not supported');
        }
        // first thing is to try to extract the client id from the assertion
        // if a clientId is present, check it matches (as per spec - it's optional but must match if supplied)
        // then find their key and validate the assertion
        const { sub: clientId } = decodeJwt(assertion.clientAssertion);
        if (!clientId) {
            throw new InvalidClientError('client_assertion malformed');
        }
        if (assertion.clientId && assertion.clientId !== clientId) {
            throw new InvalidClientError('client_id mismatch');
        }
        // somehow get the client and their keys
        const client = await getClient(clientId);
        const jwks = createLocalJWKSet({ keys: client.keys });
        // actually verify the assertion is genuine/trusted
        await jwtVerify(assertion.clientAssertion, jwks, {
            requiredClaims: [
                'iss',
                'sub',
                'aud',
                'exp',
            ],
            maxTokenAge: 60,
            audience: ['https://example.com'],
        }).catch((e) => {
            return Promise.reject(new InvalidClientError(e as Error));
        });
        // any other validation can be performed here (eg: issuer is acceptable, audience, etc)
        return client;
    }
```

