### PR TITLE
add refresh token to client_credentials saveToken

### DIFF
--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -71,10 +71,15 @@ class ClientCredentialsGrantType extends AbstractGrantType {
   async saveToken(user, client, requestedScope) {
     const validatedScope = await this.validateScope(user, client, requestedScope);
     const accessToken = await this.generateAccessToken(client, user, validatedScope);
+    const refreshToken = await this.generateRefreshToken(client, user, validatedScope);
     const accessTokenExpiresAt = await this.getAccessTokenExpiresAt(client, user, validatedScope);
+    const refreshTokenExpiresAt = await this.getRefreshTokenExpiresAt();
+    
     const token = {
       accessToken,
       accessTokenExpiresAt,
+      refreshToken,
+      refreshTokenExpiresAt,
       scope: validatedScope,
     };
 


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------- 

🎉 THANK YOU FOR YOUR CONTRIBUTION! 🎉

We highly appreciate your time and effort to this project!


⚠ PLEASE READ THIS FIRST ⚠

1. If this is a fix for a security vulnerability you discovered please don't 
just open this PR until we have privately discussed the vulnerability. Disclosing 
it without contacting us can lead to severe implications for many applications 
that run on this project.

2. Make sure you have read the contribution guidelines for this project in
order to raise the chance of getting your PR accepted. This saves you valuable 
time and effort.

3. The following structure is a basic guideline. If a section does not apply you
can remove it.
---------------------------------------------------------------------------- -->

## Summary
TLDR: fixes #350 

For some reason, the library doesn't include the refresh token when saving the access token during client_credentials flows, but it does for the authorization_code flow. In the event that you need to generate tokens for anonymous users (guests), the client credentials grant is necessary, and the refresh token should be provided.



## Linked issue(s)
#350 



## Involved parts of the project
client_credentials grant flow



## Added tests?
No tests



## OAuth2 standard
https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.17 (page 44)
https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/ (refresh token section)



## Reproduction
Issue a token using client_credentials grant and see the refresh token now exists as it does for the authorization_code grant
