### PR TITLE
feat: Implement ID-JAG

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,23 @@ declare namespace OAuth2Server {
         redirect(url: string): void;
     }
 
+    /**
+     * JWT Bearer grant type (RFC 7523 / ID-JAG Cross App Access).
+     *
+     * Accepts a JWT Bearer assertion — typically an ID-JAG issued by an upstream
+     * Identity Provider — and exchanges it for a standard Bearer access token.
+     *
+     * Register via extendedGrantTypes:
+     *   extendedGrantTypes: {
+     *     'urn:ietf:params:oauth:grant-type:jwt-bearer': JwtBearerGrantType
+     *   }
+     *
+     * Required model methods: getUserFromJwtBearer, saveToken
+     */
+    class JwtBearerGrantType extends AbstractGrantType {
+        handle(request: Request, client: Client): Promise<Token | Falsey>;
+    }
+
     abstract class AbstractGrantType {
         /**
          * Instantiates AbstractGrantType using the supplied options.
@@ -385,6 +402,34 @@ declare namespace OAuth2Server {
     }
 
     interface ExtensionModel extends BaseModel, RequestAuthenticationModel {}
+
+    /**
+     * Model interface for the JWT Bearer grant type (RFC 7523 / ID-JAG).
+     *
+     * Used with the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant to
+     * implement the Resource AS role in Cross App Access flows.
+     */
+    interface JwtBearerModel extends BaseModel, RequestAuthenticationModel {
+        /**
+         * Invoked to validate a JWT Bearer assertion and return the associated user.
+         *
+         * The model is responsible for all cryptographic validation, including:
+         *   - For ID-JAG assertions (typ: "oauth-id-jag+jwt"):
+         *     - Verify `aud` claim matches this authorization server
+         *     - Verify `client_id` claim matches the authenticated `client.id`
+         *     - Verify IdP signature using the IdP's public keys
+         *     - Verify `exp`, `iat`, `jti` claims per RFC 7519
+         *   - For general RFC 7523 assertions: standard JWT validation
+         *
+         * Return the user object on success, or a falsy value to reject the grant.
+         */
+        getUserFromJwtBearer(assertion: string, client: Client): Promise<User | Falsey>;
+
+        /**
+         * Invoked to check if the requested scope is valid for the user/client pair.
+         */
+        validateScope?(user: User, client: Client, scope?: string[]): Promise<string[] | Falsey>;
+    }
 
     /**
      * An interface representing the user.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ exports.Response = require('./lib/response');
  */
 
 exports.AbstractGrantType = require('./lib/grant-types/abstract-grant-type');
+exports.JwtBearerGrantType = require('./lib/grant-types/jwt-bearer-grant-type');
 
 /**
  * Export error classes.

--- a/lib/grant-types/jwt-bearer-grant-type.js
+++ b/lib/grant-types/jwt-bearer-grant-type.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/*
+ * Module dependencies.
+ */
+
+const AbstractGrantType = require('./abstract-grant-type');
+const InvalidArgumentError = require('../errors/invalid-argument-error');
+const InvalidGrantError = require('../errors/invalid-grant-error');
+const InvalidRequestError = require('../errors/invalid-request-error');
+/**
+ * JWT Bearer grant type.
+ *
+ * Implements RFC 7523 (JWT Profile for OAuth 2.0 Access Token Requests) as
+ * applied to the Identity Assertion Authorization Grant (ID-JAG) defined in
+ * draft-ietf-oauth-identity-assertion-authz-grant.
+ *
+ * This grant type enables Cross App Access: an upstream Identity Provider
+ * issues an ID-JAG JWT which the client presents here (Resource AS) in
+ * exchange for a standard Bearer access token.
+ *
+ * Grant type URI: urn:ietf:params:oauth:grant-type:jwt-bearer
+ *
+ * Register via extendedGrantTypes:
+ *   new OAuth2Server({
+ *     model,
+ *     extendedGrantTypes: {
+ *       'urn:ietf:params:oauth:grant-type:jwt-bearer': JwtBearerGrantType
+ *     }
+ *   });
+ *
+ * Required model methods:
+ *   getUserFromJwtBearer(assertion, client) — validate the JWT assertion and
+ *     return the associated user, or a falsy value on failure. The model is
+ *     responsible for all cryptographic validation including:
+ *       - For ID-JAG: typ header = "oauth-id-jag+jwt", aud = this AS,
+ *         client_id claim = client.id, exp/iat checks, IdP signature
+ *       - For general RFC 7523 JWTs: standard JWT validation per RFC 7519
+ *   saveToken(token, client, user) — persist and return the issued access token
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7523
+ * @see https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/
+ */
+
+class JwtBearerGrantType extends AbstractGrantType {
+  constructor(options = {}) {
+    if (!options.model) {
+      throw new InvalidArgumentError('Missing parameter: `model`');
+    }
+
+    if (!options.model.getUserFromJwtBearer) {
+      throw new InvalidArgumentError('Invalid argument: model does not implement `getUserFromJwtBearer()`');
+    }
+
+    if (!options.model.saveToken) {
+      throw new InvalidArgumentError('Invalid argument: model does not implement `saveToken()`');
+    }
+
+    super(options);
+  }
+
+  /**
+   * Handle JWT Bearer grant.
+   *
+   * @see https://www.rfc-editor.org/rfc/rfc7523#section-2.1
+   */
+
+  async handle(request, client) {
+    if (!request) {
+      throw new InvalidArgumentError('Missing parameter: `request`');
+    }
+
+    if (!client) {
+      throw new InvalidArgumentError('Missing parameter: `client`');
+    }
+
+    const scope = this.getScope(request);
+    const user = await this.getUserFromJwtBearer(request, client);
+
+    return this.saveToken(user, client, scope);
+  }
+
+  /**
+   * Retrieve the user from a JWT Bearer assertion.
+   *
+   * Validation of the assertion contents (signature, claims, expiry, etc.)
+   * is fully delegated to model.getUserFromJwtBearer().
+   */
+
+  async getUserFromJwtBearer(request, client) {
+    if (!request.body.assertion) {
+      throw new InvalidRequestError('Missing parameter: `assertion`');
+    }
+
+    const user = await this.model.getUserFromJwtBearer(request.body.assertion, client);
+
+    if (!user) {
+      throw new InvalidGrantError('Invalid grant: assertion is invalid');
+    }
+
+    return user;
+  }
+
+  /**
+   * Save token.
+   *
+   * No refresh token is issued — this grant type represents client-to-client
+   * federation; the client re-presents the upstream assertion to obtain a
+   * new access token when needed.
+   */
+
+  async saveToken(user, client, requestedScope) {
+    const validatedScope = await this.validateScope(user, client, requestedScope);
+    const accessToken = await this.generateAccessToken(client, user, validatedScope);
+    const accessTokenExpiresAt = this.getAccessTokenExpiresAt();
+
+    const token = {
+      accessToken,
+      accessTokenExpiresAt,
+      scope: validatedScope,
+    };
+
+    return this.model.saveToken(token, client, user);
+  }
+}
+
+/*
+ * Export constructor.
+ */
+
+module.exports = JwtBearerGrantType;

--- a/test/integration/grant-types/jwt-bearer-grant-type_test.js
+++ b/test/integration/grant-types/jwt-bearer-grant-type_test.js
@@ -1,0 +1,411 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const JwtBearerGrantType = require('../../../lib/grant-types/jwt-bearer-grant-type');
+const InvalidArgumentError = require('../../../lib/errors/invalid-argument-error');
+const InvalidGrantError = require('../../../lib/errors/invalid-grant-error');
+const InvalidRequestError = require('../../../lib/errors/invalid-request-error');
+const Request = require('../../../lib/request');
+const should = require('chai').should();
+
+/**
+ * Test `JwtBearerGrantType` integration.
+ */
+
+describe('JwtBearerGrantType integration', function() {
+  describe('constructor()', function() {
+    it('should throw an error if `model` is missing', function() {
+      try {
+        new JwtBearerGrantType();
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidArgumentError);
+        e.message.should.equal('Missing parameter: `model`');
+      }
+    });
+
+    it('should throw an error if the model does not implement `getUserFromJwtBearer()`', function() {
+      try {
+        new JwtBearerGrantType({ model: {} });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidArgumentError);
+        e.message.should.equal('Invalid argument: model does not implement `getUserFromJwtBearer()`');
+      }
+    });
+
+    it('should throw an error if the model does not implement `saveToken()`', function() {
+      try {
+        const model = {
+          getUserFromJwtBearer: function() {}
+        };
+
+        new JwtBearerGrantType({ model: model });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidArgumentError);
+        e.message.should.equal('Invalid argument: model does not implement `saveToken()`');
+      }
+    });
+
+    it('should not throw an error when `model` implements required methods', function() {
+      const model = {
+        getUserFromJwtBearer: function() {},
+        saveToken: function() {}
+      };
+
+      new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+    });
+  });
+
+  describe('handle()', function() {
+    it('should throw an error if `request` is missing', async function() {
+      const model = {
+        getUserFromJwtBearer: function() {},
+        saveToken: function() {}
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+
+      try {
+        await grantType.handle();
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidArgumentError);
+        e.message.should.equal('Missing parameter: `request`');
+      }
+    });
+
+    it('should throw an error if `client` is missing', async function() {
+      const model = {
+        getUserFromJwtBearer: function() {},
+        saveToken: function() {}
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({ body: { assertion: 'header.payload.sig' }, headers: {}, method: {}, query: {} });
+
+      try {
+        await grantType.handle(request);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidArgumentError);
+        e.message.should.equal('Missing parameter: `client`');
+      }
+    });
+
+    it('should throw an error if `assertion` is missing from request body', async function() {
+      const model = {
+        getUserFromJwtBearer: function() {},
+        saveToken: function() {}
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({ body: {}, headers: {}, method: {}, query: {} });
+
+      try {
+        await grantType.handle(request, {});
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidRequestError);
+        e.message.should.equal('Missing parameter: `assertion`');
+      }
+    });
+
+    it('should throw an error if the assertion is rejected by the model', async function() {
+      const model = {
+        getUserFromJwtBearer: async function() { return null; },
+        saveToken: function() {}
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      try {
+        await grantType.handle(request, {});
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidGrantError);
+        e.message.should.equal('Invalid grant: assertion is invalid');
+      }
+    });
+
+    it('should return a token', async function() {
+      const token = {};
+      const client = { id: 'client-id' };
+      const user = { id: 'user-id' };
+      const assertion = 'header.payload.sig';
+      const scope = ['read'];
+
+      const model = {
+        getUserFromJwtBearer: async function(_assertion, _client) {
+          _assertion.should.equal(assertion);
+          _client.should.deep.equal(client);
+          return { ...user };
+        },
+        saveToken: async function(_token, _client, _user) {
+          _client.should.deep.equal(client);
+          _user.should.deep.equal(user);
+          _token.accessToken.should.equal('long-access-token-hash');
+          _token.accessTokenExpiresAt.should.be.instanceOf(Date);
+          _token.scope.should.eql(scope);
+          should.not.exist(_token.refreshToken);
+          return token;
+        },
+        validateScope: async function(_user, _client, _scope) {
+          _user.should.deep.equal(user);
+          _client.should.deep.equal(client);
+          _scope.should.eql(scope);
+          return scope;
+        },
+        generateAccessToken: async function(_client, _user, _scope) {
+          _client.should.deep.equal(client);
+          _user.should.deep.equal(user);
+          _scope.should.eql(scope);
+          return 'long-access-token-hash';
+        }
+      };
+
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: assertion, scope: scope.join(' ') },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      const data = await grantType.handle(request, client);
+      data.should.equal(token);
+    });
+
+    it('should not include a refresh token in the saved token', async function() {
+      const client = { id: 'client-id' };
+      const user = { id: 'user-id' };
+
+      const model = {
+        getUserFromJwtBearer: async function() { return user; },
+        saveToken: async function(_token) {
+          should.not.exist(_token.refreshToken);
+          should.not.exist(_token.refreshTokenExpiresAt);
+          return _token;
+        }
+      };
+
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      await grantType.handle(request, client);
+    });
+
+    it('should support promises', function() {
+      const token = {};
+      const model = {
+        getUserFromJwtBearer: async function() { return {}; },
+        saveToken: async function() { return token; }
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      grantType.handle(request, {}).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support non-promises', function() {
+      const token = {};
+      const model = {
+        getUserFromJwtBearer: function() { return {}; },
+        saveToken: function() { return token; }
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      grantType.handle(request, {}).should.be.an.instanceOf(Promise);
+    });
+  });
+
+  describe('getUserFromJwtBearer()', function() {
+    it('should throw an error if `assertion` is missing', async function() {
+      const model = {
+        getUserFromJwtBearer: function() {},
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({ body: {}, headers: {}, method: {}, query: {} });
+
+      try {
+        await grantType.getUserFromJwtBearer(request, {});
+
+        should.fail();
+      } catch (e) {
+        e.should.be.an.instanceOf(InvalidRequestError);
+        e.message.should.equal('Missing parameter: `assertion`');
+      }
+    });
+
+    it('should throw an error if the model returns a falsy user', function() {
+      const model = {
+        getUserFromJwtBearer: function() { return null; },
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      return grantType.getUserFromJwtBearer(request, {})
+        .then(should.fail)
+        .catch(function(e) {
+          e.should.be.an.instanceOf(InvalidGrantError);
+          e.message.should.equal('Invalid grant: assertion is invalid');
+        });
+    });
+
+    it('should return a user', function() {
+      const user = { id: 'user-id' };
+      const model = {
+        getUserFromJwtBearer: function() { return user; },
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      return grantType.getUserFromJwtBearer(request, {})
+        .then(function(data) {
+          data.should.equal(user);
+        })
+        .catch(should.fail);
+    });
+
+    it('should pass assertion and client to model', async function() {
+      const assertion = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig';
+      const client = { id: 'my-client' };
+      let capturedAssertion, capturedClient;
+
+      const model = {
+        getUserFromJwtBearer: function(a, c) {
+          capturedAssertion = a;
+          capturedClient = c;
+          return { id: 'user' };
+        },
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: assertion },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      await grantType.getUserFromJwtBearer(request, client);
+      capturedAssertion.should.equal(assertion);
+      capturedClient.should.equal(client);
+    });
+
+    it('should support promises', function() {
+      const user = { id: 'user-id' };
+      const model = {
+        getUserFromJwtBearer: async function() { return user; },
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      grantType.getUserFromJwtBearer(request, {}).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support non-promises', function() {
+      const user = { id: 'user-id' };
+      const model = {
+        getUserFromJwtBearer: function() { return user; },
+        saveToken: () => should.fail()
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 120, model: model });
+      const request = new Request({
+        body: { assertion: 'header.payload.sig' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+
+      grantType.getUserFromJwtBearer(request, {}).should.be.an.instanceOf(Promise);
+    });
+  });
+
+  describe('saveToken()', function() {
+    it('should save the token without a refresh token', async function() {
+      const token = {};
+      const model = {
+        getUserFromJwtBearer: () => should.fail(),
+        saveToken: function(_token, _client, _user) {
+          should.not.exist(_token.refreshToken);
+          return token;
+        },
+        validateScope: function() { return ['foo']; }
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 123, model: model });
+      const data = await grantType.saveToken({}, {}, ['foo']);
+      data.should.equal(token);
+    });
+
+    it('should support promises', function() {
+      const token = {};
+      const model = {
+        getUserFromJwtBearer: () => should.fail(),
+        saveToken: async function() { return token; }
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken({}, {}, []).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support non-promises', function() {
+      const token = {};
+      const model = {
+        getUserFromJwtBearer: () => should.fail(),
+        saveToken: function() { return token; }
+      };
+      const grantType = new JwtBearerGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken({}, {}, []).should.be.an.instanceOf(Promise);
+    });
+  });
+});


### PR DESCRIPTION

## Summary
Provide an implementation of the RFC 7523 only as an authorization grant to support an ID-JAG to be provided for exchange.



## Linked issue(s)


## Involved parts of the project
It's a new grant type `urn:ietf:params:oauth:grant-type:jwt-bearer` used in server-to-server scenarios

## Added tests?
I have added tests of the  

## OAuth2 standard
https://datatracker.ietf.org/doc/html/rfc7523 (only as an authorization grant, not section 2.2)
https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/

## Reproduction
<!-- ---------------------------------------------------------------------------
⚠ How can we reproduce your changes in an app? This is especially important
when new features are added
---------------------------------------------------------------------------- -->

Here's a diff against the server2server example in the node-oauth2-server-examples repot that adds ID-JAG support. The flow: an upstream IdP issues a signed JWT; the consumer presents it to the Resource AS (the provider) in exchange for a bearer token.                    
                                                                                
  ---                                                                           
  server2server/provider/package.json                                           
                                                                                
     "dependencies": {                                                          
       "@node-oauth/express-oauth-server": "^4.0.0",                            
  +    "@node-oauth/oauth2-server": "^5.3.0",                                   
       "body-parser": "^1.20.2",                                                
       "dotenv": "^16.3.1",                                                     
  -    "express": "^4.18.2"                                                     
  +    "express": "^4.18.2",                                                    
  +    "jsonwebtoken": "^9.0.0"                                                 
     },                                                                         
                                                                                
  ---
  server2server/provider/index.js

   const bodyParser = require('body-parser');
   const express = require('express');
   const OAuthServer = require('@node-oauth/express-oauth-server');
  +const { JwtBearerGrantType } = require('@node-oauth/oauth2-server');
   const createModel = require('./model');
   const DB = require('./db');

   const db = new DB();
   const app = express();
   const oauth = new OAuthServer({
  -  model: createModel(db)
  +  model: createModel(db),
  +  extendedGrantTypes: {
  +    'urn:ietf:params:oauth:grant-type:jwt-bearer': JwtBearerGrantType
  +  }
   });

   db.saveClient({
     id: process.env.CLIENT_ID,
     secret: process.env.CLIENT_SECRET,
  -  grants: ['client_credentials']
  +  grants: ['client_credentials',
  'urn:ietf:params:oauth:grant-type:jwt-bearer']
   });

  ---
  server2server/provider/model.js

  +const jwt = require('jsonwebtoken');
  +
   const enabledScopes = ['read', 'write'];
   const getUserDoc = () => ({ id: 'system' });

  +// The audience value this AS uses as its own identifier.
  +// Incoming ID-JAG assertions must have `aud` equal to this value.
  +const AS_IDENTIFIER = process.env.AS_IDENTIFIER || 'http://localhost:8080';
  +
   function createModel (db) {
     async function getClient (clientId, clientSecret) {
       return db.findClient(clientId, clientSecret);
     }

  +  /**
  +   * Validate an ID-JAG assertion (RFC 7523 /
  draft-ietf-oauth-identity-assertion-authz-grant).
  +   *
  +   * The IdP's RSA public key must be in IDP_PUBLIC_KEY (PEM format).
  +   * Returns a user object on success, or false to reject the grant.
  +   */
  +  async function getUserFromJwtBearer(assertion, client) {
  +    // Decode without verifying so we can inspect the typ header first.
  +    const decoded = jwt.decode(assertion, { complete: true });
  +    if (!decoded) {
  +      return false;
  +    }
  +
  +    // ID-JAG requires typ = 'oauth-id-jag+jwt' (Section 4 of the ID-JAG
  draft).
  +    if (decoded.header.typ !== 'oauth-id-jag+jwt') {
  +      return false;
  +    }
  +
  +    let payload;
  +    try {
  +      // jwt.verify checks signature, exp, and aud in one call.
  +      payload = jwt.verify(assertion, process.env.IDP_PUBLIC_KEY, {
  +        algorithms: ['RS256'],
  +        audience: AS_IDENTIFIER,
  +      });
  +    } catch (_err) {
  +      return false;
  +    }
  +
  +    // client_id claim must match the authenticated client making this
  request.
  +    if (payload.client_id !== client.id) {
  +      return false;
  +    }
  +
  +    // sub is the user identity asserted by the IdP.
  +    return { id: payload.sub };
  +  }
  +
     async function validateScope (user, client, scope) {

     return {
       getClient,
       saveToken,
       getAccessToken,
       getRefreshToken,
       revokeToken,
       validateScope,
       verifyScope,
  -    getUserFromClient
  +    getUserFromClient,
  +    getUserFromJwtBearer
     };
   }

  ---
  server2server/provider/.env additions

  +# ID-JAG: identifier this AS uses for itself (must match `aud` in incoming
  JWTs)
  +AS_IDENTIFIER=http://localhost:8080
  +
  +# ID-JAG: the IdP's RSA public key in PEM format (newlines replaced with \n
  for .env)
  +# Generate a test key pair:
  +#   openssl genrsa -out idp_private.pem 2048
  +#   openssl rsa -in idp_private.pem -pubout -out idp_public.pem
  +IDP_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n..."

  ---
  server2server/consumer/idjag.js (new file)

  This simulates an app that has already received an ID-JAG JWT from an IdP and
  exchanges it for an access token at the Resource AS.

  import fs from 'fs';
  import fetch from 'node-fetch';
  import jwt from 'jsonwebtoken';

  const rootUrl = 'http://localhost:8080';
  // const log = (...args) => console.log('[ID-JAG Consumer]:', ...args);

  const getBody = async (response) => {
    const body = await response.text();
    log('=> response:', response.status, response.statusText, body, '\n');
    return body;
  };

  const run = async () => {
    const client = {
      id: process.env.CLIENT_ID,
      secret: process.env.CLIENT_SECRET,
    };

    // --- Step 1: Simulate receiving an ID-JAG JWT from an upstream IdP. ---
    // In production the IdP signs this; here we sign it locally with a test key
    // to demonstrate the full exchange. IDP_PRIVATE_KEY holds the RS256 private
   key.
    const idpPrivateKey = process.env.IDP_PRIVATE_KEY.replace(/\\n/g, '\n');

    const assertion = jwt.sign(
      {
        iss: process.env.IDP_ISSUER || 'https://idp.example.com',
        sub: 'user-123',                      // the user the IdP is asserting
        aud: process.env.AS_IDENTIFIER || 'http://localhost:8080',
        client_id: client.id,                 // the client presenting this JWT
        iat: Math.floor(Date.now() / 1000),
      },
      idpPrivateKey,
      {
        algorithm: 'RS256',
        expiresIn: '5m',
        header: {
          alg: 'RS256',
          typ: 'oauth-id-jag+jwt',            // required by the ID-JAG draft
        },
      }
    );

    log('ID-JAG assertion generated (sub=user-123)\n');

    // --- Step 2: Exchange the ID-JAG JWT for an access token at the Resource
  AS. ---
    const tokenParams = new URLSearchParams();
    tokenParams.append('grant_type',
  'urn:ietf:params:oauth:grant-type:jwt-bearer');
    tokenParams.append('assertion', assertion);
    tokenParams.append('scope', 'read');

    const tokenResponse = await fetch(`${rootUrl}/token`, {
      method: 'POST',
      body: tokenParams,
      headers: {
        'Content-Type': 'application/x-www-form-urlencoded',
        // Client authenticates itself to the AS via HTTP Basic Auth.
        'Authorization': 'Basic ' +
  Buffer.from(`${client.id}:${client.secret}`).toString('base64'),
      },
    });

    const tokenBody = await getBody(tokenResponse);
    const { access_token: accessToken, token_type: tokenType } =
  JSON.parse(tokenBody);

    if (!accessToken) {
      log('Token exchange failed.');
      return;
    }
    log('Access token obtained via ID-JAG exchange!\n');

    // --- Step 3: Use the access token to call a protected resource. ---
    log('GET /read-resource (authenticated as user-123)');
    const resourceResponse = await fetch(`${rootUrl}/read-resource`, {
      headers: { 'Authorization': `${tokenType} ${accessToken}` },
    });
    await getBody(resourceResponse);
  };

  run().catch(console.error);

  ---
  Key points:
  - All JWT validation lives in getUserFromJwtBearer on the model. Signature,
  exp, aud, and client_id checks. Returning false causes the framework to throw
  invalid_grant.
  - The typ: 'oauth-id-jag+jwt' header check is what distinguishes an ID-JAG
  assertion from a generic RFC 7523 JWT.
  - Client still authenticates via HTTP Basic Auth on the token request: the
  assertion identifies the user, not the client.
  - No refresh token is issued (the client re-presents a fresh ID-JAG assertion
  when the access token expires).
  - In production, IDP_PUBLIC_KEY would typically be fetched dynamically from
  the IdP's JWKS endpoint (https://idp.example.com/.well-known/jwks.json) rather than stored as a static env var.
