### PR TITLE
fix(types): OAuthError.inner, saveToken input, and getClient clientSecret

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -258,7 +258,7 @@ declare namespace OAuth2Server {
          * Invoked to retrieve a client using a client id or a client id/client secret combination, depending on the grant type.
          *
          */
-        getClient(clientId: string, clientSecret: string): Promise<Client | Falsey>;
+        getClient(clientId: string, clientSecret?: string): Promise<Client | Falsey>;
 
         /**
          * Invoked to save an access token and optionally a refresh token, depending on the grant type.

--- a/index.d.ts
+++ b/index.d.ts
@@ -464,6 +464,11 @@ declare namespace OAuth2Server {
          * A human-readable error message.
          */
         message: string;
+
+        /**
+         * The original error, present when this error was constructed by wrapping another `Error`.
+         */
+        inner?: Error;
     }
 
     class AccessDeniedError extends OAuthError {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -264,7 +264,7 @@ declare namespace OAuth2Server {
          * Invoked to save an access token and optionally a refresh token, depending on the grant type.
          *
          */
-        saveToken(token: Token, client: Client, user: User): Promise<Token | Falsey>;
+        saveToken(token: Omit<Token, 'client' | 'user'>, client: Client, user: User): Promise<Token | Falsey>;
     }
 
     interface RequestAuthenticationModel {


### PR DESCRIPTION
## What

Three `index.d.ts` typing corrections.

Closes #367. Closes #368.

## Changes

**`fix(types): add missing OAuthError.inner property`** (#367)

`OAuthError` sets `this.inner` to the wrapped error when constructed from another `Error` ([oauth-error.js](https://github.com/node-oauth/node-oauth2-server/blob/master/lib/errors/oauth-error.js#L30-L32)), and the handlers do exactly that (`new ServerError(e)`), but the property was missing from the published typings. Added `inner?: Error`. Thanks @papermana for the report.

> Note: @wille suggested exposing the wrapped error via the standard `Error.cause` instead. That's a good idea, but it's a runtime change — this PR just documents the property that already exists. Adopting `.cause` (keeping `.inner` as a deprecated alias) would be a sensible follow-up.

**`fix(types): correct saveToken input to exclude client/user`** (#368)

The grant types call `model.saveToken()` with a token object that does **not** include `client`/`user` — they're passed as separate arguments and must be present on the **returned** value (`TokenModel` requires them). Typing the input as the full `Token` let `saveToken(token) { return token }` type-check while throwing at runtime. Narrowed the input to `Omit<Token, 'client' | 'user'>`. Thanks @papermana.

**`fix(types): allow getClient clientSecret to be omitted`**

The token handler calls `model.getClient()` with no client secret for public / PKCE clients (`clientSecret` is `undefined`), and the docs describe it as nullable, but the typing required a `string`. Made it optional (`clientSecret?: string`). This addresses the secondary typing point raised by @Valerionn in #281's thread.

## Notes

- Verified `index.d.ts` still compiles cleanly (`tsc --noEmit --strict`).
- The `saveToken` change is a **type-only tightening**: it can surface (correct) compile errors in consumer code that relied on the old, inaccurate type. No runtime change — but you may prefer to release it in a minor rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
