### PR TITLE
docs: clarify the consumer must send the response / redirect

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -81,6 +81,45 @@ oauth.authenticate(request, response)
     });
 ```
 
+### Sending the response
+
+This library is **framework-agnostic and does not send the HTTP response for you**.
+`authenticate()`, `authorize()` and `token()` resolve with their result *and*
+populate the `Response` object you passed in — setting `response.status`,
+`response.headers` and `response.body`. It is up to you to copy those onto your
+framework's real response and send it. For `authorize()` this is how the redirect
+happens: the `location` header is set on the `Response`, but you still have to
+issue it.
+
+A minimal Express example for the authorization endpoint:
+
+```js
+app.get('/authorize', async (req, res) => {
+    // Wrap the framework objects in NEW variables — see the warning below.
+    const request = new Request(req);
+    const response = new Response(res);
+
+    try {
+        await oauth.authorize(request, response, { authenticateHandler });
+    } catch (err) {
+        return res.status(err.code || 500).json({ error: err.name, error_description: err.message });
+    }
+
+    // The library populated `response`; now you send it. For authorize that is a redirect:
+    res.set(response.headers);                // includes the `location` header
+    return res.status(response.status).end(); // 302 -> the browser follows `location`
+});
+```
+
+> **Do not reassign your framework's `req`/`res`** to the library's objects
+> (e.g. `res = new Response(res)`). Doing so discards framework methods such as
+> `res.redirect()`, and is a common cause of a request appearing to "hang".
+
+If you use Express or Koa, prefer the official adapters
+([express-oauth-server](https://www.npmjs.com/package/@node-oauth/express-oauth-server),
+[koa-oauth-server](https://npmjs.org/package/koa-oauth-server)), which take care of
+all of this for you.
+
 The most crucial part in this setup is the `model`.
 It acts as the bridge between the OAuth2 server library and your system.
 


### PR DESCRIPTION
## What

Adds a **"Sending the response"** section to the getting-started guide, clarifying that the library is framework-agnostic and **does not send the HTTP response itself** — `authenticate()`/`authorize()`/`token()` only *populate* the `Response` object (`status`, `headers`, `body`); the consumer transfers those onto their framework's real response and issues the redirect for `authorize()`.

## Why

Recurring confusion (see #333): users call `authorize()` and expect the redirect to happen automatically. The specific trap is reassigning the framework's `req`/`res` to the library's `Request`/`Response` (`res = new Response(res)`), which discards `res.redirect()` and makes the request appear to "hang". jankapunkt asked for this to be documented.

## Changes

- `docs/guide/getting-started.md`: new section with a minimal Express `authorize` example, a warning against reassigning `req`/`res`, and a pointer to the official adapters.
- Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
