### PR TITLE
docs(contributing): add documentation PR guidance targeting master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,34 @@ generated from our internal JSDoc comments.
 Instead, update the comments directly within the code and run `npm run docs:api`
 to generate the api docs.
 
+### Documentation Pull Requests
+
+Documentation fixes are a valuable contribution. However, the PR workflow for
+**docs-only changes** differs from the regular development workflow:
+
+- Open your pull request targeting the **`master`** branch, not `development`
+
+This is because the published docs at [readthedocs.io](https://node-oauth2-server.readthedocs.io)
+always reflect the `master` branch. A docs fix merged into `development` would
+either require waiting for the next release cycle or force merging potentially
+unstable code from `development` into `master`.
+
+To contribute a docs-only fix:
+
+```bash
+git clone git@github.com:node-oauth/node-oauth2-server.git
+cd node-oauth2-server
+git checkout master            # start from master, not development
+git checkout -b docs/fix-xyz   # create a descriptive branch
+```
+
+Make your changes in the `docs/` directory (guide pages) or as JSDoc comments
+in the source files (API docs are generated automatically). Then open your PR
+targeting `master`.
+
+> **Note:** if your change touches both documentation and code, please follow
+> the standard development workflow and target `development` instead.
+
 ### Building the docs
 
 Run `npm run docs:build` to build the docs.


### PR DESCRIPTION
## Summary

Adds a new **"Documentation Pull Requests"** section to `CONTRIBUTING.md` explaining that docs-only fixes should target `master` instead of `development`. This resolves the ambiguity raised in #221.

The root cause: the published docs on readthedocs.io always point to `master`, so a fix merged only into `development` either waits behind the next release or forces merging unstable code into `master`.

## Changes
- New `### Documentation Pull Requests` subsection in the Documentation chapter
- Explains why docs PRs target `master` (not `development`)
- Provides a step-by-step snippet for checking out from `master`
- Includes a note for mixed code+docs PRs (use `development` as usual)

Closes #221