### PR TITLE
feat(token-handler): distinguish public and confidential clients #81

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -406,6 +406,7 @@ declare namespace OAuth2Server {
         grants: string | string[];
         accessTokenLifetime?: number;
         refreshTokenLifetime?: number;
+        type?: 'public' | 'confidential';
         [key: string]: any;
     }
 

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -122,10 +122,6 @@ class TokenHandler {
       throw new InvalidRequestError('Missing parameter: `client_id`');
     }
 
-    if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret && !isPkce) {
-      throw new InvalidRequestError('Missing parameter: `client_secret`');
-    }
-
     if (!isFormat.vschar(credentials.clientId)) {
       throw new InvalidRequestError('Invalid parameter: `client_id`');
     }
@@ -135,7 +131,7 @@ class TokenHandler {
     }
 
     try {
-      const client = await this.model.getClient(credentials.clientId, credentials.clientSecret);
+      const client = await this.model.getClient(credentials.clientId, credentials.clientSecret ?? null);
 
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
@@ -147,6 +143,10 @@ class TokenHandler {
 
       if (!(client.grants instanceof Array)) {
         throw new ServerError('Server error: `grants` must be an array');
+      }
+
+      if (this.isClientAuthenticationRequired(grantType, client) && !credentials.clientSecret && !isPkce) {
+        throw new InvalidClientError('Invalid client: client is invalid');
       }
 
       return client;
@@ -195,10 +195,8 @@ class TokenHandler {
       }
     }
 
-    if (!this.isClientAuthenticationRequired(grantType)) {
-      if (request.body.client_id) {
-        return { clientId: request.body.client_id };
-      }
+    if (request.body.client_id) {
+      return { clientId: request.body.client_id };
     }
 
     throw new InvalidClientError('Invalid client: cannot retrieve client credentials');
@@ -305,7 +303,9 @@ class TokenHandler {
   /**
    * Given a grant type, check if client authentication is required
    */
-  isClientAuthenticationRequired(grantType) {
+  isClientAuthenticationRequired(grantType, client) {
+    if (client && client.type === 'public') return false;
+
     if (Object.keys(this.requireClientAuthentication).length > 0) {
       return typeof this.requireClientAuthentication[grantType] !== 'undefined'
         ? this.requireClientAuthentication[grantType]

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -132,7 +132,7 @@ class TokenHandler {
     }
 
     try {
-      const client = await this.model.getClient(credentials.clientId, credentials.clientSecret ?? null);
+      const client = await this.model.getClient(credentials.clientId, credentials.clientSecret || null);
 
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -190,12 +190,6 @@ class TokenHandler {
       };
     }
 
-    if (pkce.isPKCERequest({ grantType, codeVerifier })) {
-      if (request.body.client_id) {
-        return { clientId: request.body.client_id };
-      }
-    }
-
     if (request.body.client_id) {
       return { clientId: request.body.client_id };
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -46,6 +46,7 @@ const ServerError = require('./errors/server-error');
  * @property grants {string[]} Grant types allowed for the client.
  * @property accessTokenLifetime {number} Client-specific lifetime of generated access tokens in seconds.
  * @property refreshTokenLifetime {number} Client-specific lifetime of generated refresh tokens in seconds.
+ * @property type {string} The client type: `public` or `confidential`. Defaults to 'confidential' when not set.
  */
 
 /**

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -766,6 +766,98 @@ describe('TokenHandler integration', function () {
         .catch(should.fail);
     });
 
+    describe('with a public client and no `client_secret`', function () {
+      it('should return the client without requiring a secret', function () {
+        const client = { id: 'foo', grants: ['authorization_code'], type: 'public' };
+        const model = Model.from({
+          getClient: function () {
+            return client;
+          },
+          saveToken: function () {},
+        });
+        const handler = new TokenHandler({
+          accessTokenLifetime: 120,
+          model: model,
+          refreshTokenLifetime: 120,
+        });
+        const request = new Request({
+          body: { client_id: 'foo', grant_type: 'authorization_code' },
+          headers: {},
+          method: {},
+          query: {},
+        });
+
+        return handler
+          .getClient(request)
+          .then(function (data) {
+            data.should.equal(client);
+          })
+          .catch(should.fail);
+      });
+    });
+
+    describe('with a confidential client (explicit type) and no `client_secret`', function () {
+      it('should throw an error', function () {
+        const client = { id: 'foo', grants: ['authorization_code'], type: 'confidential' };
+        const model = Model.from({
+          getClient: function () {
+            return client;
+          },
+          saveToken: function () {},
+        });
+        const handler = new TokenHandler({
+          accessTokenLifetime: 120,
+          model: model,
+          refreshTokenLifetime: 120,
+        });
+        const request = new Request({
+          body: { client_id: 'foo', grant_type: 'authorization_code' },
+          headers: {},
+          method: {},
+          query: {},
+        });
+
+        return handler
+          .getClient(request)
+          .then(should.fail)
+          .catch(function (e) {
+            e.should.be.an.instanceOf(InvalidClientError);
+            e.message.should.equal('Invalid client: client is invalid');
+          });
+      });
+    });
+
+    describe('with a confidential client (no type, default) and no `client_secret`', function () {
+      it('should throw an error', function () {
+        const client = { id: 'foo', grants: ['password'] };
+        const model = Model.from({
+          getClient: function () {
+            return client;
+          },
+          saveToken: function () {},
+        });
+        const handler = new TokenHandler({
+          accessTokenLifetime: 120,
+          model: model,
+          refreshTokenLifetime: 120,
+        });
+        const request = new Request({
+          body: { client_id: 'foo', grant_type: 'password' },
+          headers: {},
+          method: {},
+          query: {},
+        });
+
+        return handler
+          .getClient(request)
+          .then(should.fail)
+          .catch(function (e) {
+            e.should.be.an.instanceOf(InvalidClientError);
+            e.message.should.equal('Invalid client: client is invalid');
+          });
+      });
+    });
+
     describe('with `password` grant type and `requireClientAuthentication` is false', function () {
       it('should return a client ', function () {
         const client = { id: 12345, grants: [] };
@@ -909,7 +1001,7 @@ describe('TokenHandler integration', function () {
       }
     });
 
-    it('should throw an error if `client_secret` is missing', async function () {
+    it('should return credentials with only `clientId` when `client_secret` is missing', function () {
       const model = Model.from({
         getClient: function () {},
         saveToken: function () {},
@@ -926,14 +1018,8 @@ describe('TokenHandler integration', function () {
         query: {},
       });
 
-      try {
-        await handler.getClientCredentials(request);
-
-        should.fail();
-      } catch (e) {
-        e.should.be.an.instanceOf(InvalidClientError);
-        e.message.should.equal('Invalid client: cannot retrieve client credentials');
-      }
+      const credentials = handler.getClientCredentials(request);
+      credentials.should.eql({ clientId: 'foo' });
     });
 
     describe('with `client_id` and grant type is `password` and `requireClientAuthentication` is false', function () {

--- a/test/unit/handlers/token-handler_test.js
+++ b/test/unit/handlers/token-handler_test.js
@@ -45,7 +45,7 @@ describe('TokenHandler', function () {
         .catch(should.fail);
     });
 
-    it('should call `model.getClient()` with no secret is provided (public client)', function () {
+    it('should call `model.getClient()` when no client secret is provided (public client)', function () {
       const model = Model.from({
         getClient: sinon.stub().returns({ grants: ['authorization_code'], type: 'public' }),
         saveToken: function () {},

--- a/test/unit/handlers/token-handler_test.js
+++ b/test/unit/handlers/token-handler_test.js
@@ -16,7 +16,7 @@ const should = require('chai').should();
 
 describe('TokenHandler', function () {
   describe('getClient()', function () {
-    it('should call `model.getClient()`', function () {
+    it('should call `model.getClient()` with the provided secret', function () {
       const model = Model.from({
         getClient: sinon.stub().returns({ grants: ['password'] }),
         saveToken: function () {},
@@ -41,6 +41,33 @@ describe('TokenHandler', function () {
           model.getClient.firstCall.args[0].should.equal(12345);
           model.getClient.firstCall.args[1].should.equal('secret');
           model.getClient.firstCall.thisValue.should.equal(model);
+        })
+        .catch(should.fail);
+    });
+
+    it('should call `model.getClient()` with no secret is provided (public client)', function () {
+      const model = Model.from({
+        getClient: sinon.stub().returns({ grants: ['authorization_code'], type: 'public' }),
+        saveToken: function () {},
+      });
+      const handler = new TokenHandler({
+        accessTokenLifetime: 120,
+        model: model,
+        refreshTokenLifetime: 120,
+      });
+      const request = new Request({
+        body: { client_id: 'foo', grant_type: 'authorization_code' },
+        headers: {},
+        method: {},
+        query: {},
+      });
+
+      return handler
+        .getClient(request)
+        .then(function () {
+          model.getClient.callCount.should.equal(1);
+          model.getClient.firstCall.args[0].should.equal('foo');
+          should.equal(model.getClient.firstCall.args[1], null);
         })
         .catch(should.fail);
     });


### PR DESCRIPTION
## Summary

RFC 6749 4.1.3 requires public clients be allowed to omit client_secret at the token endpoint. getClientCredentials() previously rejected requests missing a secret before the model was ever consulted, so client.type could never be checked. Moved checking the secret requirement to after the client is fetched so it can be decided based on client.type.

Obs.: Unified the error message to prevent leaking whether a client exists. Both unknown clients and clients missing their required secret now return the same InvalidClientError("Invalid client: client is invalid").


## Linked issue(s)

#81 


## Involved parts of the project

- lib/handlers/token-handler.js — getClient(), getClientCredentials(), isClientAuthenticationRequired()
- lib/model.js — ClientData typedef (type property documented)
- index.d.ts — Client interface (type?: 'public' | 'confidential')
- Affected flow: token endpoint (/token) client authentication, all grant types


## Added tests?

- test/integration/handlers/token-handler_test.js: public client with no client_secret succeeds; confidential client (explicit type) with no client_secret throws; confidential client (default, no type set) with no client_secret throws — verifies fail-closed default.
- test/unit/handlers/token-handler_test.js: model.getClient() is called with null (not undefined) when no secret is provided.


## OAuth2 standard

RFC 6749 §4.1.3 (Access Token Request) — public clients are not required to authenticate with a client_secret; confidential clients are. This PR adds an optional client.type ('public' | 'confidential') to the model contract, defaulting to 'confidential' when unset (fail-closed — existing integrations that never set type keep requiring a secret, no behavior change for them).


## Reproduction

```js
// model implementation
async function getClient(clientId, clientSecret) {
  const client = await db.findClient(clientId);
  if (!client) return null;
  if (client.type !== 'public' && client.secret !== clientSecret) return null;
  return client;
}

// POST /token
// (no client_secret) -> now succeeds if client.type === 'public'
// confidential client omitting client_secret -> still rejected (InvalidClientError)
```

